### PR TITLE
fixes #132 to have page name link in the wiki plugin working on Windows OS

### DIFF
--- a/hawtio-git/src/main/java/io/hawt/git/FileInfo.java
+++ b/hawtio-git/src/main/java/io/hawt/git/FileInfo.java
@@ -30,7 +30,7 @@ public class FileInfo {
     private final boolean directory;
 
     public static FileInfo createFileInfo(File rootDir, File file) {
-        String path = getRelativePath(rootDir, file);
+        String path = getRelativePath(rootDir, file).replace("\\", "/");
         return new FileInfo(path, file.getName(), file.lastModified(), file.length(), file.isDirectory());
     }
 


### PR DESCRIPTION
Fixed on the server side in the Git facade to abstract the client side and AngularJS routing from the OS file path discrepancies.
