### PR TITLE
Make hawtio-dev-mode work regardless of location of hawtio clone

### DIFF
--- a/hawtio-karaf/src/main/resources/features.xml
+++ b/hawtio-karaf/src/main/resources/features.xml
@@ -43,7 +43,7 @@
 
     <config name="hawtiodev-hawtioweb">
       context=/hawtio/*
-      content=${karaf.home}/../../../../../hawtio/hawtio-web/target/hawtio-web-${project.version}
+      content=${project.basedir}/../hawtio-web/target/hawtio-web-${project.version}
     </config>
 
   </feature>

--- a/hawtio-web/src/main/webapp/app/osgi/js/bundles.ts
+++ b/hawtio-web/src/main/webapp/app/osgi/js/bundles.ts
@@ -35,7 +35,7 @@ module Osgi {
       },
       {
         field: 'SymbolicName',
-        displayName: 'SymbolicName',
+        displayName: 'Symbolic Name',
         width: "***",
         cellTemplate: '<div class="ngCellText"><a href="#/osgi/bundle/{{row.entity.Identifier}}">{{row.getProperty(col.field)}}</a></div>'
       },


### PR DESCRIPTION
A small pull request to get started :)
Change how the location of hawtio is recorded in the hawtio-dev-mode feature. Previously the clone was required to be called 'hawtio' and share a common parent with where fuse fabric was running. This is now changed to be the absolute path of where hawtio is built.

Also fixes a typo for Bundles display label: SymbolicName -> Symbolic Name
