### PR TITLE
#150 Unify the list and table-based bundle views under a single tab.

### DIFF
--- a/hawtio-web/src/main/webapp/app/osgi/html/bundle-list.html
+++ b/hawtio-web/src/main/webapp/app/osgi/html/bundle-list.html
@@ -1,5 +1,13 @@
 <div ng-controller="Osgi.BundleListController">
     <div class="row-fluid">
+        <div id="tab" class="btn-group pull-right" data-toggle="buttons-radio">
+            <p/>
+            <a href="#/osgi/bundle-list" class="btn btn-primary active">List View</a>
+            <a href="#/osgi/bundles" class="btn btn-primary">Table View</a>
+        </div>
+    </div>
+
+    <div class="row-fluid">
         <div class="control-group">
             <form class="form-inline">
                 <div class="input-append pull-left">

--- a/hawtio-web/src/main/webapp/app/osgi/html/bundles.html
+++ b/hawtio-web/src/main/webapp/app/osgi/html/bundles.html
@@ -1,6 +1,14 @@
 <div ng-controller="Osgi.BundlesController">
-  
-  <div class="row-fluid">
+    <div class="row-fluid">
+        <div id="tab" class="btn-group pull-right" data-toggle="buttons-radio">
+            <p/>
+            <a href="#/osgi/bundle-list" class="btn btn-primary">List View</a>
+            <a href="#/osgi/bundles" class="btn btn-primary active">Table View</a>
+            <p/>
+        </div>
+    </div>
+
+    <div class="row-fluid">
     <div class="pull-left">
       <form class="form-inline no-bottom-margin">
         <fieldset>

--- a/hawtio-web/src/main/webapp/app/osgi/html/layoutOsgi.html
+++ b/hawtio-web/src/main/webapp/app/osgi/html/layoutOsgi.html
@@ -1,9 +1,6 @@
 <ul class="nav nav-tabs" ng-controller="Core.NavBarController">
     <li ng-class='{active : isActive("#/osgi/bundle")}'>
-        <a ng-href="#/osgi/bundles{{hash}}">Bundles</a>
-    </li>
-    <li ng-class='{active : isActive("#/osgi/bundle")}'>
-        <a ng-href="#/osgi/bundle-list{{hash}}">Bundle List</a>
+        <a ng-href="#/osgi/bundle-list{{hash}}">Bundles</a>
     </li>
     <li ng-class='{active : isActive("#/osgi/package")}'>
         <a ng-href="#/osgi/packages{{hash}}">Packages</a>

--- a/hawtio-web/src/main/webapp/app/osgi/js/osgiPlugin.ts
+++ b/hawtio-web/src/main/webapp/app/osgi/js/osgiPlugin.ts
@@ -2,9 +2,9 @@ module Osgi {
   var pluginName = 'osgi';
   angular.module(pluginName, ['bootstrap', 'ngResource', 'ngGrid', 'hawtioCore']).config(($routeProvider) => {
     $routeProvider.
+            when('/osgi/bundle-list', {templateUrl: 'app/osgi/html/bundle-list.html'}).
             when('/osgi/bundles', {templateUrl: 'app/osgi/html/bundles.html'}).
             when('/osgi/bundle/:bundleId', {templateUrl: 'app/osgi/html/bundle.html'}).
-            when('/osgi/bundle-list', {templateUrl: 'app/osgi/html/bundle-list.html'}).
             when('/osgi/services', {templateUrl: 'app/osgi/html/services.html'}).
             when('/osgi/packages', {templateUrl: 'app/osgi/html/packages.html'}).
             when('/osgi/package/:package/:version', {templateUrl: 'app/osgi/html/package.html'}).
@@ -19,7 +19,7 @@ module Osgi {
               content: "OSGi",
               title: "Visualise and manage the bundles and services in this OSGi container",
               isValid: (workspace: Workspace) => workspace.treeContainsDomainAndProperties("osgi.core"),
-              href: () => "#/osgi/bundles",
+              href: () => "#/osgi/bundle-list",
               isActive: (workspace: Workspace) => workspace.isLinkActive("osgi")
             });
 


### PR DESCRIPTION
You can switch between them using a little button-bar on the top-right.
I've been a little cheeky in making the list-based bundle view the default. Am happy to revert that if it upsets someone ;-)
