### PR TITLE
fixed jvm switch

### DIFF
--- a/hawtio-web/src/main/webapp/app/core/js/preferences.ts
+++ b/hawtio-web/src/main/webapp/app/core/js/preferences.ts
@@ -34,7 +34,7 @@ module Core {
 
     $scope.gotoServer = (url) => {
       console.log("going to server: " + url);
-      window.open("#/?url=" + encodeURIComponent(url));
+      window.open("?url=" + encodeURIComponent(url));
     }
   }
 }


### PR DESCRIPTION
The `Go To Server` button did not work as the [parseQueryString](https://github.com/hawtio/hawtio/blob/master/hawtio-web/src/main/webapp/app/core/js/corePlugin.ts#L9) seems to fail for hashbang urls. 

The url before:

`http://host:port#/?url=some.url`

The url now:

`http://host:port?url=some.url#some/frontend/route`
