### PR TITLE
Fix OSX build.

### DIFF
--- a/hawtio-local-jvm-mbean/pom.xml
+++ b/hawtio-local-jvm-mbean/pom.xml
@@ -30,7 +30,7 @@
       <artifactId>tools</artifactId>
       <version>1.6</version>
       <scope>system</scope>
-      <systemPath>${java.home}/../lib/tools.jar</systemPath>
+      <systemPath>${toolsjar}</systemPath>
     </dependency>
 
     <dependency>
@@ -99,5 +99,31 @@
       </plugin>
     </plugins>
   </build>
-
+  
+  <profiles>
+    <profile>
+      <id>default-profile</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+        <file>
+          <exists>${java.home}/../lib/tools.jar</exists>
+        </file>
+      </activation>
+      <properties>
+        <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
+      </properties>
+    </profile>
+    <profile>
+      <id>mac-profile</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <file>
+          <exists>${java.home}/../Classes/classes.jar</exists>
+        </file>
+      </activation>
+      <properties>
+        <toolsjar>${java.home}/../Classes/classes.jar</toolsjar>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Without this the build on OSX with Java 6 fails as follows:
[ERROR] Failed to execute goal on project hawtio-local-jvm-mbean: Could not resolve dependencies for project io.hawt:hawtio-local-jvm-mbean:bundle:1.2-SNAPSHOT: Could not find artifact com.sun:tools:jar:1.6 at specified path /System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home/../lib/tools.jar
