### PR TITLE
Changed site-base.less due to layout issue with first option in side navbar menu

### DIFF
--- a/hawtio-web/src/main/webapp/css/site-base.less
+++ b/hawtio-web/src/main/webapp/css/site-base.less
@@ -861,7 +861,7 @@ div#main div div div div div.logbar div.logbar-container ul.nav.nav-tabs {
 
 .help-sidebar li:first-child {
   margin-top: 0px !important;
-  padding-top: 3px;
+  padding-top: 20px;
 }
 
 .help-display img:not(.no-shadow) {


### PR DESCRIPTION
Solved layout issue with first option of the sidebar navbar menu. Camel menu text is now completely visible. 
