### PR TITLE
Added silent to the findComponentNames Bean-Call

### DIFF
--- a/hawtio-web/src/main/webapp/app/camel/js/endpointChooser.ts
+++ b/hawtio-web/src/main/webapp/app/camel/js/endpointChooser.ts
@@ -236,7 +236,7 @@ module Camel {
       var mbean = findCamelContextMBean();
       if (mbean) {
         //$scope.jolokia.execute(mbean, 'findComponentNames', onSuccess(onComponents, silentOptions));
-        $scope.jolokia.execute(mbean, 'findComponentNames', onSuccess(onComponents));
+        $scope.jolokia.execute(mbean, 'findComponentNames', onSuccess(onComponents, {silent: true}));
 /*
         $scope.jolokia.execute(mbean, 'findComponentNames', onSuccess(onComponents, {error: function (response) {
           console.log("FAILED: " + response);


### PR DESCRIPTION
otherwise it prompts an gigantic error if the Version is <2.12 on the page everytime that functions gets called. And that happens a lot
