### PR TITLE
made google maps urls protocol relative

### DIFF
--- a/hawtio-web/src/main/webapp/app/fabric/js/map.ts
+++ b/hawtio-web/src/main/webapp/app/fabric/js/map.ts
@@ -26,7 +26,7 @@ module Fabric {
 
     Fabric.startMaps = $scope.start
 
-    $('body').append('<script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=false&async=2&callback=Fabric.startMaps"></script>');
+    $('body').append('<script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=false&async=2&callback=Fabric.startMaps"></script>');
 
     $scope.addMarker = function ($event) {
       $scope.myMarkers.push(new google.maps.Marker({

--- a/hawtio-web/src/main/webapp/index.html
+++ b/hawtio-web/src/main/webapp/index.html
@@ -312,7 +312,7 @@ TODO add patch for dashboard until angular supports nested custom injections
 
 <!-- google maps -->
 <!--
-<script src="http://maps.googleapis.com/maps/api/js?sensor=false" type="text/javascript"></script>
+<script src="//maps.googleapis.com/maps/api/js?sensor=false" type="text/javascript"></script>
     -->
 </body>
 </html>


### PR DESCRIPTION
The google maps feature breaks ssl encryption. This PR makes them protocol relative.
