### PR TITLE
Adding some eye candy to force graph directive.

### DIFF
--- a/hawtio-web/src/main/webapp/app/forcegraph/js/graphBuilder.ts
+++ b/hawtio-web/src/main/webapp/app/forcegraph/js/graphBuilder.ts
@@ -4,6 +4,7 @@ module ForceGraph {
 
         private nodes = {};
         private links = [];
+        private linkTypes = {};
 
         public addNode(node) {
             if(!this.nodes[node.id]) {
@@ -20,11 +21,18 @@ module ForceGraph {
                 target: targetNode,
                 type: linkType
             });
+
+            if (!this.linkTypes[linkType]) {
+                this.linkTypes[linkType] = {
+                    used: true
+                }
+            };
         }
 
         public buildGraph() {
 
             var graphNodes = d3.values(this.nodes);
+            var linktypes  = d3.keys(this.linkTypes);
             var graphLinks = [];
 
             var nodeIndex = (id, nodes) => {
@@ -52,7 +60,8 @@ module ForceGraph {
 
             return {
                 nodes: graphNodes,
-                links: graphLinks
+                links: graphLinks,
+                linktypes: linktypes
             }
         }
     }

--- a/hawtio-web/src/main/webapp/app/osgi/html/svc-dependencies.html
+++ b/hawtio-web/src/main/webapp/app/osgi/html/svc-dependencies.html
@@ -13,14 +13,14 @@
         stroke-dasharray: 0,2 1;
     }
 
-    marker#licensing {
-        fill: green;
-    }
-
     circle {
         fill: #ccc;
         stroke: #333;
         stroke-width: 1.5px;
+    }
+
+    circle.bundle {
+        fill: green;
     }
 
     text {
@@ -37,45 +37,7 @@
 <div ng-controller="Osgi.ServiceDependencyController">
   
   <div id="canvas">
-    <div hawtio-force-graph graph="graph"></div>
+    <div hawtio-force-graph graph="graph" link-distance="100" charge="-300" nodesize="10"></div>
   </div>
-
-<!--
-    <div class="row-fluid">
-        <div class="span12">
-            <div id="canvas" >
-                <svg width=0 height=0>
-                    <defs>
-                        <marker id="arrowhead"
-                                viewBox="0 0 10 10"
-                                refX="8"
-                                refY="5"
-                                markerUnits="strokeWidth"
-                                markerWidth="8"
-                                markerHeight="5"
-                                orient="auto"
-                                style="fill: #333">
-                            <path d="M 0 0 L 10 5 L 0 10 z"></path>
-                        </marker>
-
-                        <filter id="drop-shadow" width="150%" height="150%">
-                            <feGaussianBlur in="SourceAlpha" result="blur-out" stdDeviation="2"/>
-                            <feOffset in="blur-out" result="the-shadow" dx="2" dy="2"/>
-                            <feBlend in="SourceGraphic" in2="the-shadow" mode="normal"/>
-                        </filter>
-                        <linearGradient id="rect-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                            <stop offset="0%" style="stop-color:rgb(254,254,255);stop-opacity:1"/>
-                            <stop offset="100%" style="stop-color:rgb(247,247,255);stop-opacity:1"/>
-                        </linearGradient>
-                        <linearGradient id="rect-select-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                            <stop offset="0%" style="stop-color:#d9edf7;stop-opacity:1"/>
-                            <stop offset="100%" style="stop-color:#c9ddf7;stop-opacity:1"/>
-                        </linearGradient>
-                    </defs>
-                </svg>
-            </div>
-        </div>
-    </div>
--->
 
 </div>

--- a/hawtio-web/src/main/webapp/app/osgi/js/svc-dependencies.ts
+++ b/hawtio-web/src/main/webapp/app/osgi/js/svc-dependencies.ts
@@ -6,10 +6,7 @@ module Osgi {
             Core.$apply($scope);
         });
 
-        $scope.graph = {
-            nodes: {},
-            links: []
-        }
+        createGraph()
 
         function createGraph() {
 
@@ -24,7 +21,9 @@ module Osgi {
                    var bundleNodeId = "Bundle-" + bundle.Identifier;
                    var bundleNode = {
                        id: bundleNodeId,
-                       name: bundle.SymbolicName
+                       name: bundle.SymbolicName,
+                       type: "bundle",
+                       navUrl: "#/osgi/bundle/" + bundle.Identifier
                    }
 
                    bundle.RegisteredServices.forEach((sid) => {
@@ -32,7 +31,8 @@ module Osgi {
                        var svcNodeId = "Service-" + sid;
                        var svcNode = {
                            id: svcNodeId,
-                           name: "" + sid
+                           name: "" + sid,
+                           type: "service"
                        };
 
                        graphBuilder.addLink(bundleNode, svcNode, "registered");
@@ -43,7 +43,9 @@ module Osgi {
                        var svcNodeId = "Service-" + sid;
                        var svcNode = {
                            id: svcNodeId,
-                           name: "" + sid
+                           name: "" + sid,
+                           type: "service",
+                           image: null
                        };
 
                        graphBuilder.addLink(bundleNode, svcNode, "inuse");
@@ -52,7 +54,6 @@ module Osgi {
             });
 
             $scope.graph = graphBuilder.buildGraph();
-
         }
     }
 


### PR DESCRIPTION
Graph directive now allows to include navigation urls and images in the raw graph data. The directive uses the raw d3 API to create the graph accordingly.
