### PR TITLE
basic support for jetty-9 and SPDY

### DIFF
--- a/hawtio-web/src/main/webapp/app/jetty/html/connectors.html
+++ b/hawtio-web/src/main/webapp/app/jetty/html/connectors.html
@@ -1,6 +1,24 @@
 <div class="row-fluid" ng-controller="Jetty.ConnectorsController">
 
-    <div class="row-fluid">
+  <div class="row-fluid">
+
+    <div class="pull-left">
+      <form class="form-inline no-bottom-margin">
+        <fieldset>
+          <div class="controls control-group inline-block controls-row">
+            <div class="btn-group">
+              <button ng-disabled="selected.length == 0 || everySelectionIsRunning()"
+                      class="btn" ng-click="start()" title="Start"> <i class="icon-play-circle"></i> </button>
+              <button ng-disabled="selected.length == 0 || !anySelectionIsRunning()"
+                      class="btn" ng-click="stop()" title="Stop"> <i class="icon-off"></i></button>
+              
+            </div>
+          </div>
+        </fieldset>
+      </form>
+
+    </div>
+
         <div class="pull-right">
             <form class="form-inline no-bottom-margin">
                 <fieldset>

--- a/hawtio-web/src/main/webapp/app/jetty/js/jetty.ts
+++ b/hawtio-web/src/main/webapp/app/jetty/js/jetty.ts
@@ -42,7 +42,6 @@ module Jetty {
       data: 'webapps',
       displayFooter: true,
       selectedItems: $scope.selected,
-      selectWithCheckboxOnly: true,
       columnDefs: columnDefs,
       filterOptions: {
         filterText: ''


### PR DESCRIPTION
I've:
- split render into render78 and render9
- added a column to support the jetty 9 concept that a connector can handle multiple protocols
- faked the protocols column for jetty-7/8
- added start/stop buttons to the connectors tab
