### PR TITLE
Error: Could not find or load main class io.hawt.plugin.App

### DIFF
--- a/hawtio-app/pom.xml
+++ b/hawtio-app/pom.xml
@@ -53,7 +53,7 @@
           </descriptors>
           <archive>
             <manifest>
-              <mainClass>io.hawt.plugin.App</mainClass>
+              <mainClass>io.hawt.app.App</mainClass>
             </manifest>
           </archive>
         </configuration>


### PR DESCRIPTION
Typing `java -jar hawtio-app-1.3.0.jar` results in `Error: Could not find or load main class io.hawt.plugin.App` since the package name in the manifest is off.
