### PR TITLE
Fix the 2 tsc compilation errors on hawtio-web

### DIFF
--- a/hawtio-web/src/main/d.ts/sugar-1.3.d.ts
+++ b/hawtio-web/src/main/d.ts/sugar-1.3.d.ts
@@ -1536,7 +1536,7 @@ interface Number {
 	upto(num: number, fn?: Function, step?: number): number[];
 }
 
-interface Array {
+interface Array<T> {
 	
 	/***
 	* @short Alternate array constructor.

--- a/hawtio-web/src/main/webapp/app/camel/js/pageTitle.ts
+++ b/hawtio-web/src/main/webapp/app/camel/js/pageTitle.ts
@@ -30,7 +30,7 @@ module Core {
           }
         }
         return answer;
-      }).exclude(excludes).exclude('');
+      }).exclude(<any> excludes).exclude('');
     }
   }
 


### PR DESCRIPTION
Fix for the following 2 tsc compilation errors on `hawtio-web`

```
[ERROR] /Users/bvahdat/dev/workspace/hawtio/hawtio-web/src/main/d.ts/sugar-1.3.d.ts(1539,11): error TS2234: All declarations of an interface must have identical type parameters.
[ERROR] /Users/bvahdat/dev/workspace/hawtio/hawtio-web/src/main/webapp/app/camel/js/pageTitle.ts(33,10): error TS2082: Supplied parameters do not match any signature of call target:
[ERROR]     Could not apply type 'number' to argument 1 which is of type 'string[]'.
[ERROR] /Users/bvahdat/dev/workspace/hawtio/hawtio-web/src/main/webapp/app/camel/js/pageTitle.ts(33,10): error TS2087: Could not select overload for 'call' expression.
[ERROR] Failed to execute tsc. Return code: 1
```
