### PR TITLE
Fix #1173 'mvn install' fails when using Java 8 due to stricter javadoc ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
   </prerequisites>
 
   <properties>
+    <additionalparam>-Xdoclint:none</additionalparam>
     <jettyPort>8080</jettyPort>
     <context>/hawtio</context>
     <hawtio-config-dir>${basedir}/hawtio-config</hawtio-config-dir>


### PR DESCRIPTION
How to verify: 
Point JAVA_HOME to Java 8.
''mvn install'''.

I personally prefer the alternative solution: fixing the javadoc, since this solution will allow even more "broken" javadoc.
