### PR TITLE
spring-batch plugin - Fix for retrieving job and step execution contexts from the renamed endpoints. 

### DIFF
--- a/hawtio-web/src/main/java/io/hawt/web/ContextFormatterServlet.java
+++ b/hawtio-web/src/main/java/io/hawt/web/ContextFormatterServlet.java
@@ -30,10 +30,10 @@ public class ContextFormatterServlet extends HttpServlet {
         }
 
         if(contextType.equals("jobExecution")){
-            url= server+"jobs/executions/"+jobExecutionId+"/context.json";
+            url= server+"jobs/executions/"+jobExecutionId+"/execution-context.json";
             paramString="jobExecutionContext";
         }else if(contextType.equals("stepExecution")){
-            url= server+"jobs/executions/"+jobExecutionId+"/steps/"+stepExecutionId+"/context.json";
+            url= server+"jobs/executions/"+jobExecutionId+"/steps/"+stepExecutionId+"/execution-context.json";
             paramString="stepExecutionContext";
         }
         HttpClient client = new HttpClient();


### PR DESCRIPTION
This fix contains the changes in the URLs for retrieving job and step execution contexts of a spring batch according to the new patch submitted to the spring-batch-admin-manager. 
Here's the JIRA issue for the patch submitted to spring-batch-admin-manager:
https://jira.spring.io/browse/BATCHADM-179
