### PR TITLE
ENTESB-1203 - Removed description field from abstract node. This prevent...

### DIFF
--- a/hawtio-web/src/main/webapp/lib/camelModel.js
+++ b/hawtio-web/src/main/webapp/lib/camelModel.js
@@ -122,10 +122,6 @@ var _apacheCamelModel = {
         "id": {
           "type": "string"
         },
-        "description": {
-          "type": "string",
-          "formTemplate": "<textarea class='input-xxlarge' rows='8'></textarea>"
-        },
         "inheritErrorHandler": {
           "type": "java.lang.Boolean"
         }


### PR DESCRIPTION
...s the generation of a non valid xml. Haven't reintroduce it yet in the correct node form haveing found most of the components widget non working. Needs longer refactoring/extension to support description nodes

https://issues.jboss.org/browse/ENTESB-1203
