### PR TITLE
Added validation to container names. Now using an already existing name for a container prevents the submission and shows an error message. Fixes #1235

### DIFF
--- a/hawtio-web/src/main/webapp/app/fabric/html/createContainer.html
+++ b/hawtio-web/src/main/webapp/app/fabric/html/createContainer.html
@@ -22,9 +22,15 @@
       <ol class="zebra-list">
         <li ng-repeat="field in forms.create_container.$error.pattern">
           <strong class="red">{{massage(field.$name) | humanize}}</strong>
-          <span ng-switch="field.$name">
-            <span ng-switch-when="name">can only contain letters, numbers, '-' and '_'</span>
-          </span>
+            <span ng-switch="field.$name">
+              <span ng-switch-when="name">can only contain letters, numbers, '-' and '_'</span>
+            </span>
+        </li>
+        <li ng-repeat="field in forms.create_container.$error.taken">
+          <strong class="red">{{massage(field.$name) | humanize}}</strong>
+            <span ng-switch="field.$name">
+              <span ng-switch-when="name">is already in use</span>
+            </span>
         </li>
       </ol>
       <div ng-show="forms.create_container.$valid">

--- a/hawtio-web/src/main/webapp/app/fabric/js/fabricPlugin.ts
+++ b/hawtio-web/src/main/webapp/app/fabric/js/fabricPlugin.ts
@@ -169,19 +169,39 @@ module Fabric {
     directive('fabricVersionLink', (workspace, jolokia, localStorage) => {
         return {
             restrict: 'A',
-            link: ($scope, $element, $attrs) => {
-            var versionLink = $attrs['fabricVersionLink'];
+              link: ($scope, $element, $attrs) => {
+                  var versionLink = $attrs['fabricVersionLink'];
 
-            if (versionLink && !versionLink.isBlank() && Fabric.fabricCreated(workspace)) {
-              var container = Fabric.getCurrentContainer(jolokia, ['versionId']);
-              var versionId = container['versionId'] || "1.0";
-              if (versionId && !versionId.isBlank()) {
-                var url = "#/wiki/branch/" + versionId + "/" + Core.trimLeading(versionLink, "/");
-                $element.attr('href', url);
+                  if (versionLink && !versionLink.isBlank() && Fabric.fabricCreated(workspace)) {
+                      var container = Fabric.getCurrentContainer(jolokia, ['versionId']);
+                      var versionId = container['versionId'] || "1.0";
+                      if (versionId && !versionId.isBlank()) {
+                          var url = "#/wiki/branch/" + versionId + "/" + Core.trimLeading(versionLink, "/");
+                          $element.attr('href', url);
+                      }
+                  }
               }
-            }
-          }
-        }
+         }
+      }).
+    directive('containerNameAvailable', (workspace, jolokia, localStorage) => {
+        return {
+              restrict: 'A',
+              require: 'ngModel',
+              link: ($scope, $element, $attrs, $ctrl) => {
+                  $ctrl.$parsers.unshift(function(viewValue) {
+                      var found = $scope.child.rootContainers.indexOf(viewValue);
+                      if (found !== -1) {
+                          // it is invalid, return undefined (no model update)
+                          $ctrl.$setValidity('taken', false);
+                          return undefined;
+                      } else {
+                          // it is valid
+                          $ctrl.$setValidity('taken', true);
+                          return viewValue;
+                      }
+                  });
+              }
+         }
     }).
     factory('serviceIconRegistry', () => {
         return Fabric.serviceIconRegistry;

--- a/hawtio-web/src/main/webapp/app/fabric/js/schemaConfigure.ts
+++ b/hawtio-web/src/main/webapp/app/fabric/js/schemaConfigure.ts
@@ -51,6 +51,9 @@ module Fabric {
     Core.pathSet(schema, ['properties','version', 'type'], 'hidden');
 
     Core.pathSet(schema.properties, ['name', 'label'], 'Container Name');
+    Core.pathSet(schema.properties, ['name', 'container-name-available'], 'true');
+
+
     Core.pathSet(schema.properties, ['name', 'tooltip'], 'Name of the container to create (or prefix of the container name if you create multiple containers)');
 
     Core.pathSet(schema.properties, ['number', 'label'], 'Number of containers');


### PR DESCRIPTION
- Was there a way to bind custom validation directly to the form metadata without writing an angular directive like I did?
