### PR TITLE
ActiveMQ: Added edit and resend message functionality

### DIFF
--- a/hawtio-web/src/main/webapp/app/activemq/html/browseQueue.html
+++ b/hawtio-web/src/main/webapp/app/activemq/html/browseQueue.html
@@ -11,6 +11,11 @@
                   title="Moves the dead letter queue message back to its original destination so it can be retried" data-placement="bottom">
             <i class="icon-reply"></i> Retry
           </button>
+          <button class="btn" ng-disabled="gridOptions.selectedItems.length !== 1" ng-click="resendMessage()"
+                    title="Edit the message to resend it" data-placement="bottom">
+           <i class="icon-share-alt"></i> Resend
+          </button>
+
           <button class="btn" ng-disabled="!gridOptions.selectedItems.length" ng-click="moveDialog = true"
                   title="Move the selected messages to another destination" data-placement="bottom">
             <i class="icon-share-alt"></i> Move

--- a/hawtio-web/src/main/webapp/app/activemq/js/browse.ts
+++ b/hawtio-web/src/main/webapp/app/activemq/js/browse.ts
@@ -1,6 +1,6 @@
 /// <reference path="activemqPlugin.ts"/>
 module ActiveMQ {
-  export var BrowseQueueController = _module.controller("ActiveMQ.BrowseQueueController", ["$scope", "workspace", "jolokia", "localStorage", ($scope, workspace:Workspace, jolokia, localStorage) => {
+  export var BrowseQueueController = _module.controller("ActiveMQ.BrowseQueueController", ["$scope", "workspace", "jolokia", "localStorage", '$location', "activeMQMessage", ($scope, workspace:Workspace, jolokia, localStorage, location, activeMQMessage) => {
 
     $scope.searchText = '';
 
@@ -93,22 +93,33 @@ module ActiveMQ {
 
     ActiveMQ.decorate($scope);
 
-    $scope.moveMessages = () => {
-        var selection = workspace.selection;
-        var mbean = selection.objectName;
-        if (mbean && selection) {
-          var selectedItems = $scope.gridOptions.selectedItems;
-          $scope.message = "Moved " + Core.maybePlural(selectedItems.length, "message" + " to " + $scope.queueName);
-            var operation = "moveMessageTo(java.lang.String, java.lang.String)";
-            angular.forEach(selectedItems, (item, idx) => {
-                var id = item.JMSMessageID;
-                if (id) {
-                    var callback = (idx + 1 < selectedItems.length) ? intermediateResult : moveSuccess;
-                    jolokia.execute(mbean, operation, id, $scope.queueName, onSuccess(callback));
-                }
-            });
-        }
-    };
+      $scope.moveMessages = () => {
+          var selection = workspace.selection;
+          var mbean = selection.objectName;
+          if (mbean && selection) {
+              var selectedItems = $scope.gridOptions.selectedItems;
+              $scope.message = "Moved " + Core.maybePlural(selectedItems.length, "message" + " to " + $scope.queueName);
+              var operation = "moveMessageTo(java.lang.String, java.lang.String)";
+              angular.forEach(selectedItems, (item, idx) => {
+                  var id = item.JMSMessageID;
+                  if (id) {
+                      var callback = (idx + 1 < selectedItems.length) ? intermediateResult : moveSuccess;
+                      jolokia.execute(mbean, operation, id, $scope.queueName, onSuccess(callback));
+                  }
+              });
+          }
+      };
+
+      $scope.resendMessage = () => {
+          var selection = workspace.selection;
+          var mbean = selection.objectName;
+          if (mbean && selection) {
+              var selectedItems = $scope.gridOptions.selectedItems;
+              //always assume a single message
+              activeMQMessage.message = selectedItems[0];
+              location.path('activemq/sendMessage');
+          }
+      };
 
     $scope.deleteMessages = () => {
       var selection = workspace.selection;

--- a/hawtio-web/src/main/webapp/app/camel/js/camelPlugin.ts
+++ b/hawtio-web/src/main/webapp/app/camel/js/camelPlugin.ts
@@ -41,6 +41,10 @@ module Camel {
 
   _module.filter('camelIconClass', () => iconClass);
 
+  _module.factory('activeMQMessage', () => {
+      return { 'message' : null}
+  });
+
   _module.run(["workspace", "jolokia", "viewRegistry", "layoutFull", "helpRegistry", "preferencesRegistry", (workspace:Workspace, jolokia, viewRegistry, layoutFull, helpRegistry, preferencesRegistry) => {
 
     viewRegistry['camel/endpoint/'] = layoutFull;

--- a/hawtio-web/src/main/webapp/app/camel/js/send.ts
+++ b/hawtio-web/src/main/webapp/app/camel/js/send.ts
@@ -1,6 +1,6 @@
 /// <reference path="camelPlugin.ts"/>
 module Camel {
-  _module.controller("Camel.SendMessageController", ["$route", "$scope", "$element", "$timeout", "workspace", "jolokia", "localStorage", "$location", ($route, $scope, $element, $timeout, workspace:Workspace, jolokia, localStorage, $location) => {
+  _module.controller("Camel.SendMessageController", ["$route", "$scope", "$element", "$timeout", "workspace", "jolokia", "localStorage", "$location", "activeMQMessage", ($route, $scope, $element, $timeout, workspace:Workspace, jolokia, localStorage, $location, activeMQMessage) => {
     var log:Logging.Logger = Logger.get("Camel");
 
     log.info("Loaded page!");
@@ -11,6 +11,9 @@ module Camel {
     $scope.profileFileNameToProfileId = {};
     $scope.selectedFiles = {};
     $scope.container = {};
+    $scope.message = "\n\n\n\n";
+    $scope.headers = [];
+
 
     // bind model values to search params...
     Core.bindModelToSearchParam($scope, $location, "tab", "subtab", "compose");
@@ -27,6 +30,18 @@ module Camel {
       $scope.localStorage = localStorage;
       $scope.$watch('localStorage.activemqUserName', $scope.checkCredentials);
       $scope.$watch('localStorage.activemqPassword', $scope.checkCredentials);
+
+        //prefill if it's a resent
+        if(activeMQMessage.message !== null){
+           $scope.message = activeMQMessage.message.bodyText;
+           if( activeMQMessage.message.PropertiesText !== null){
+               for( var p in activeMQMessage.message.StringProperties){
+                   $scope.headers.push({name: p, value: activeMQMessage.message.StringProperties[p]});
+               }
+           }
+        }
+        // always reset at the end
+        activeMQMessage.message = null;
     }
 
     $scope.openPrefs = () => {
@@ -36,7 +51,7 @@ module Camel {
 
     var LANGUAGE_FORMAT_PREFERENCE = "defaultLanguageFormat";
     var sourceFormat = workspace.getLocalStorage(LANGUAGE_FORMAT_PREFERENCE) || "javascript";
-    $scope.message = "\n\n\n\n";
+
     // TODO Remove this if possible
     $scope.codeMirror = undefined;
     var options = {
@@ -51,8 +66,6 @@ module Camel {
       }
     };
     $scope.codeMirrorOptions = CodeEditor.createEditorSettings(options);
-
-    $scope.headers = [];
 
     $scope.addHeader = () => {
       $scope.headers.push({name: "", value: ""});


### PR DESCRIPTION
Implemented in form of an Angular shared service: "activeMQMessage". 
Please see if it's ok.

Resend button is enabled only if a single message is selected.
Clicking on resend bring the user to the composition page were custom Headers and body content are automatically prefilled.

Cover part of this request: #1391

![screenshot from 2014-07-10 16 41 51](https://cloud.githubusercontent.com/assets/1520602/3540295/a2f72764-0841-11e4-9ff1-6aeab77429a4.png)

![screenshot from 2014-07-10 16 46 23](https://cloud.githubusercontent.com/assets/1520602/3540300/a6bfda62-0841-11e4-83da-ff52f4424849.png)
