### PR TITLE
Switch to html5mode for pretty URLs

### DIFF
--- a/hawtio-web/pom.xml
+++ b/hawtio-web/pom.xml
@@ -397,7 +397,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>src/main/webapp/app</directory>
+              <directory>${basedir}/src/main/webapp/app</directory>
               <includes>
                 <include>app.js</include>
               </includes>
@@ -420,8 +420,8 @@
           </execution>
         </executions>
         <configuration>
-          <sourceDirectory>src/main/webapp/app</sourceDirectory>
-          <libraryDirectory>src/main/d.ts</libraryDirectory>
+          <sourceDirectory>${basedir}/src/main/webapp/app</sourceDirectory>
+          <libraryDirectory>${basedir}/src/main/d.ts</libraryDirectory>
           <noStandardLib>false</noStandardLib>
           <useTsc>true</useTsc>
           <targetVersion>ES5</targetVersion>
@@ -682,7 +682,7 @@
           <webAppConfig>
             <contextPath>${context}</contextPath>
             <baseResource implementation="org.eclipse.jetty.util.resource.ResourceCollection">
-              <resourcesAsCSV>src/main/webapp,${webapp-outdir}</resourcesAsCSV>
+              <resourcesAsCSV>${basedir}/src/main/webapp,${webapp-outdir}</resourcesAsCSV>
             </baseResource>
           </webAppConfig>
           <scanIntervalSeconds>0</scanIntervalSeconds>

--- a/hawtio-web/src/main/webapp/WEB-INF/web.xml
+++ b/hawtio-web/src/main/webapp/WEB-INF/web.xml
@@ -240,6 +240,7 @@
         <servlet-name>contextFormatter</servlet-name>
         <url-pattern>/contextFormatter/*</url-pattern>
     </servlet-mapping>
+
     <listener>
         <listener-class>io.hawt.HawtioContextListener</listener-class>
     </listener>
@@ -251,5 +252,11 @@
     <welcome-file-list>
         <welcome-file>index.html</welcome-file>
     </welcome-file-list>
+
+    <!-- Send root page as 404 page & let Angular do it's stuff -->
+    <error-page>
+        <error-code>404</error-code>
+        <location>/index.html</location>
+    </error-page>
 </web-app>
 

--- a/hawtio-web/src/main/webapp/app/core/js/corePlugin.ts
+++ b/hawtio-web/src/main/webapp/app/core/js/corePlugin.ts
@@ -43,7 +43,9 @@ module Core {
   export var _module = angular.module(Core.pluginName, ['bootstrap', 'ngResource', 'ui', 'ui.bootstrap.dialog', 'hawtio-ui']);
 
   // configure the module
-  _module.config(["$routeProvider", "$dialogProvider", ($routeProvider:ng.route.IRouteProvider, $dialogProvider) => {
+  _module.config(["$locationProvider", "$routeProvider", "$dialogProvider", ($locationProvider: ng.ILocationProvider, $routeProvider:ng.route.IRouteProvider, $dialogProvider) => {
+    $locationProvider.html5Mode(true);
+
     $dialogProvider.options({
       backdropFade: true,
       dialogFade: true

--- a/hawtio-web/src/main/webapp/index.html
+++ b/hawtio-web/src/main/webapp/index.html
@@ -2,6 +2,11 @@
 <html ng-csp>
 
   <head>
+    <script type="text/javascript">
+        var base = window.location.pathname.split('/', 2)[1];
+        document.write("<base href='/" + base + "/' />");
+    </script>
+
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>hawtio</title>


### PR DESCRIPTION
Switch from hashbang URLs to prettier URLs using html5mode, e.g. `/hawtio/index.html#/jvm/connect` becomes `/hawtio/jvm/connect`.

Note the switch from `index.html` to `index.jsp` to ensure base href is set to match context that the app is served under in case someone changes it from the default `/hawtio`. Using `index.jsp` as default 404 page allows this to be served if no resource is actually foumd & then AngularJS can do it's stuff, routing appropriately.

This works fine with everything I've tested, except proxy requests don't have a nice URL. They effectively look like they're local, even when they are actually proxying. Discussed in #1380 & this can be fixed later, once a better URL scheme is defined for remote connections.
