### PR TITLE
Fixed JNDI name of environment context. Websphere is picky about this

### DIFF
--- a/hawtio-system/src/main/java/io/hawt/system/ConfigManager.java
+++ b/hawtio-system/src/main/java/io/hawt/system/ConfigManager.java
@@ -25,7 +25,7 @@ public class ConfigManager {
         }
 
         try {
-            envContext = (Context) new InitialContext().lookup("java:/comp/env");
+            envContext = (Context) new InitialContext().lookup("java:comp/env");
             LOG.info("Configuration will be discovered via JNDI");
         } catch (NamingException e) {
             LOG.debug("Failed to look up environment context: ", e);


### PR DESCRIPTION
When deploying on Websphere AS 7.5, we ran into the issue that we got a naming exception. Cause was traced back to the incorrect name of the JNDI name used in the InitialContext.lookup. Removing the forward slash resolves this.
