### PR TITLE
Modified base template to allow a set of dynamic link in top right corne...

### DIFF
--- a/hawtio-web/src/main/webapp/app/core/js/navbar.ts
+++ b/hawtio-web/src/main/webapp/app/core/js/navbar.ts
@@ -8,11 +8,13 @@ module Core {
   export interface NavBarViewCustomLink {
     title: String;
     icon: String;
+    href: String;
     action: () => void;
   }
 
   export interface NavBarViewCustomLinks {
-    [name:string]:NavBarViewCustomLink;
+    list:NavBarViewCustomLink[];
+    dropDownLabel: String;
   }
 
 
@@ -208,7 +210,7 @@ module Core {
     $scope.navBarViewCustomLinks = navBarViewCustomLinks;
 
     $scope.isCustomLinkSet = () => {
-      return Object.keys($scope.navBarViewCustomLinks).length;
+      return $scope.navBarViewCustomLinks.list.length;
     }
 
     function reloadPerspective() {
@@ -240,7 +242,10 @@ module Core {
   // service that can be used by other modules to add additional links in top right corner
   _module.service("NavBarViewCustomLinks", ['$location', '$rootScope', ($location, $rootScope) => {
     //return a Map<String, Core.NavBarViewCustomLink>
-    return <NavBarViewCustomLinks>{}
+    return <NavBarViewCustomLinks>{
+      list: [],
+      label: "Extra"
+    }
   }]);
 
 }

--- a/hawtio-web/src/main/webapp/index.html
+++ b/hawtio-web/src/main/webapp/index.html
@@ -116,15 +116,15 @@ div.log-stack-trace p:nth-child(odd) {
                 <!-- dynamic links, hook for plugins-->
                 <li ng-show="loggedIn() && isCustomLinkSet() > 0 " class="dropdown">
                   <a ng-href="#"
-                     title="Red Hat Access"
+                     title="{{navBarViewCustomLinks.dropDownLabel}}"
                      data-placement="bottom"
                      class="dropdown-toggle"
                      data-toggle="dropdown">
-                    <i class="icon-user fixme"></i>&nbsp;&nbsp;<span>Red Hat Access</span>&nbsp;<span class="caret"></span>
+                    <i class="icon-user fixme"></i>&nbsp;&nbsp;<span>{{navBarViewCustomLinks.dropDownLabel}}</span>&nbsp;<span class="caret"></span>
                   </a>
                   <ul class="dropdown-menu right">
-                    <li ng-repeat="entry in navBarViewCustomLinks">
-                      <a ng-href="http://localhost:8181/hawtio/rhaccess_plugin"
+                    <li ng-repeat="entry in navBarViewCustomLinks.list">
+                      <a ng-href="{{entry.href}}"
                          ng-click="entry.action()"
                          title="{{entry.title}}">
                         <i class="{{entry.icon}}"></i>&nbsp;&nbsp;{{entry.title}}


### PR DESCRIPTION
...r.

Plugins can populate that are.

Plugins can populate with code:

```
    NavBarViewCustomLinks['1'] = {
      icon: 'icon-warning-sign',
      buttonClass: 'btn-primary',
      title: 'Open New Case',
      action: function() {
        var destination = '/rhaccess_plugin?p=container';
        var iframe = RHAccess.remoteAppEntryPoint + "#case/new";
        Logger.debug("going to: " + destination + ':' + iframe);
        RHAccessSharedProperties.iframeUrl = iframe ;
        $location.url(destination);
      }
    };
```

after they define inject in their module scope a reference to NavBarViewCustomLinks

```
module.run(function(workspace, viewRegistry, layoutFull, NavBarViewCustomLinks, $location, RHAccessSharedProperties) {
...
```

![screenshot from 2014-08-26 09 59 30](https://cloud.githubusercontent.com/assets/1520602/4041541/70612900-2cf7-11e4-8771-d214554db410.png)

fix #1470
