### PR TITLE
fixes #1526 Quartz plugin - Only update search part "nid" after selection

### DIFF
--- a/hawtio-web/src/main/webapp/app/quartz/js/quartz.ts
+++ b/hawtio-web/src/main/webapp/app/quartz/js/quartz.ts
@@ -524,7 +524,7 @@ module Quartz {
         $scope.selectedSchedulerMBean = selectionKey;
 
         // TODO: is there a better way to add our nid to the uri parameter?
-        $location.search({nid: data.key});
+        $location.search("nid", data.key);
 
         var request = [
           {type: "read", mbean: $scope.selectedSchedulerMBean}


### PR DESCRIPTION
Fix issue #1526 by only updating URI search part `nid`
