### PR TITLE
Spring boot project,to enable hawtio to be embedded in Spring boot application

### DIFF
--- a/hawtio-sample-springboot/pom.xml
+++ b/hawtio-sample-springboot/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>jolokia-core</artifactId>
             <version>${jolokia-version}</version>
         </dependency>
+        <dependency>
+        	<groupId>io.hawt</groupId>
+        	<artifactId>hawtio-springboot</artifactId>
+        	<version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hawtio-sample-springboot/src/main/java/io/hawt/sample/spring/boot/SampleSpringBootService.java
+++ b/hawtio-sample-springboot/src/main/java/io/hawt/sample/spring/boot/SampleSpringBootService.java
@@ -1,13 +1,53 @@
 package io.hawt.sample.spring.boot;
 
+import io.hawt.config.ConfigFacade;
+import io.hawt.springboot.HawtPlugin;
+import io.hawt.springboot.PluginService;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 @EnableAutoConfiguration
+@Configuration
 public class SampleSpringBootService {
 
     public static void main(String[] args) {
         new SpringApplication(SampleSpringBootService.class).run();
     }
 
+	/**
+	 * Loading an example plugin
+	 * @return
+	 */
+	@Bean
+	public HawtPlugin samplePlugin() {
+		return new HawtPlugin("sample-plugin", "/hawtio/plugins", "", new String[] { "sample-plugin/js/sample-plugin.js" });
+	}
+	
+	/**
+	 * Set things up to be in offline mode
+	 * @return
+	 * @throws Exception
+	 */
+	@Bean
+	public ConfigFacade configFacade() throws Exception {
+		ConfigFacade config = new ConfigFacade() {
+			public boolean isOffline() {
+				return true;
+			}
+		};
+		config.init();
+		return config;
+	}
+	
+	/**
+	 * Register rest endpoint to handle requests for /plugin, and return all registered plugins.
+	 * @return
+	 */
+	@Bean
+	public PluginService pluginService(){
+		return new PluginService();
+	}
 }

--- a/hawtio-sample-springboot/src/main/resources/static/hawtio/plugins/sample-plugin/html/sample-plugin.html
+++ b/hawtio-sample-springboot/src/main/resources/static/hawtio/plugins/sample-plugin/html/sample-plugin.html
@@ -1,0 +1,8 @@
+<div ng-controller="SamplePlugin.SamplePluginController">
+
+	<div class="row-fluid">
+		<h1>Demo Page</h1>
+		<p>{{message}}</p>
+	</div>
+
+</div>

--- a/hawtio-sample-springboot/src/main/resources/static/hawtio/plugins/sample-plugin/js/sample-plugin.js
+++ b/hawtio-sample-springboot/src/main/resources/static/hawtio/plugins/sample-plugin/js/sample-plugin.js
@@ -1,0 +1,41 @@
+var SamplePlugin = (function(SamplePlugin) {
+
+	SamplePlugin.pluginName = 'sample-plugin';
+	SamplePlugin.log = Logger.get('SamplePlugin');
+	SamplePlugin.contextPath = "/hawtio/plugins/";
+	SamplePlugin.templatePath = SamplePlugin.contextPath + "sample-plugin/html/";
+
+	SamplePlugin.module = angular.module('sample-plugin', ['hawtioCore'])
+      .config(function($routeProvider) {
+        $routeProvider.
+            when('/sample-plugin', {
+              templateUrl: SamplePlugin.templatePath + 'sample-plugin.html'
+            });
+      });
+
+	SamplePlugin.module.run(function(workspace, viewRegistry, layoutFull) {
+
+	SamplePlugin.log.info(SamplePlugin.pluginName, " loaded");
+    viewRegistry["sample-plugin"] = layoutFull;
+    workspace.topLevelTabs.push({
+      id: "samplePlugin",
+      content: "Sample Plugin",
+      title: "Sample plugin loaded dynamically",
+      isValid: function(workspace) { return true; },
+      href: function() { return "#/sample-plugin"; },
+      isActive: function(workspace) { return workspace.isLinkActive("sample-plugin"); }
+
+    });
+
+  });
+
+  SamplePlugin.SamplePluginController = function($scope, jolokia) {
+    $scope.message = "hello world";
+    Core.$apply($scope);    
+  };
+
+  return SamplePlugin;
+
+})(SamplePlugin || {});
+
+hawtioPluginLoader.addModule(SamplePlugin.pluginName);

--- a/hawtio-springboot/pom.xml
+++ b/hawtio-springboot/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<parent>
+		<groupId>io.hawt</groupId>
+		<artifactId>project</artifactId>
+		<version>1.5-SNAPSHOT</version>
+	</parent>
+
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>hawtio-springboot</artifactId>
+	<name>${project.artifactId}</name>
+	<description>hawtio :: hawtio-springboot</description>
+
+	<properties>
+	</properties>
+
+	<dependencies>
+
+		<dependency>
+			<artifactId>hawtio-web</artifactId>
+			<groupId>io.hawt</groupId>
+			<type>war</type>
+			<scope>provided</scope>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<artifactId>hawtio-core</artifactId>
+			<groupId>io.hawt</groupId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.hawt</groupId>
+			<artifactId>hawtio-plugin-mbean</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<version>${spring-boot-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>${jackson-version}</version>
+		</dependency>
+
+	</dependencies>
+	<build>
+		<plugins>
+			<!-- 
+			Repackage static content from war into a jar, placing static content under /static/hawtio
+			 -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>repackage</id>
+						<goals>
+							<goal>unpack-dependencies</goal>
+						</goals>
+						<phase>prepare-package</phase>
+						<configuration>
+							<outputDirectory>${project.build.directory}/classes/static/hawtio/</outputDirectory>
+							<includeArtifactIds>hawtio-web</includeArtifactIds>
+							<excludeTypes>pom</excludeTypes>
+							<excludes>**/WEB-INF/**,**/META-INF/**</excludes>
+							<excludeTransitive>true</excludeTransitive>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- 
+			angularJs html5mode makes things difficult, as it requires a server side redirect to be configured, and relying on a 404 redirect is also problematic
+			so removing this feature
+			 -->
+			<plugin>
+				<groupId>com.google.code.maven-replacer-plugin</groupId>
+				<artifactId>replacer</artifactId>
+				<version>1.5.3</version>
+				<configuration>
+					<basedir>${basedir}/target/classes/static/hawtio</basedir>
+				</configuration>
+				<executions>
+					<execution>
+						<id>removeBaseRewriteStatement</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>replace</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>index.html</include>
+							</includes>
+							<encoding>ISO-8859-1</encoding>
+							<token>document.write("&lt;base href='/" + base + "/' /&gt;");</token>
+							<value>//document.write("&lt;base href='/" + base + "/' /&gt;");</value>
+							<regex>false</regex>
+							<quiet>false</quiet>
+						</configuration>
+					</execution>
+					<execution>
+						<id>removeHtml5Mode</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>replace</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>app/app.js</include>
+							</includes>
+							<encoding>ISO-8859-1</encoding>
+							<token>$locationProvider.html5Mode(true);</token>
+							<value>$locationProvider.html5Mode(false);</value>
+							<regex>false</regex>
+							<quiet>false</quiet>
+						</configuration>
+					</execution>
+				</executions>
+
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/hawtio-springboot/src/main/java/io/hawt/springboot/HawtPlugin.java
+++ b/hawtio-springboot/src/main/java/io/hawt/springboot/HawtPlugin.java
@@ -1,0 +1,56 @@
+package io.hawt.springboot;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class HawtPlugin {
+
+	private String name;
+	private String context;
+	private String domain;
+	private String scripts[];
+
+	public HawtPlugin(String name, String context, String domain,
+			String[] scripts) {
+		super();
+		this.name = name;
+		this.context = context;
+		this.domain = domain;
+		this.scripts = scripts;
+	}
+
+	@JsonProperty("Name")
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@JsonProperty("Context")
+	public String getContext() {
+		return context;
+	}
+
+	public void setContext(String context) {
+		this.context = context;
+	}
+
+	@JsonProperty("Domain")
+	public String getDomain() {
+		return domain;
+	}
+
+	public void setDomain(String domain) {
+		this.domain = domain;
+	}
+
+	@JsonProperty("Scripts")
+	public String[] getScripts() {
+		return scripts;
+	}
+
+	public void setScripts(String[] scripts) {
+		this.scripts = scripts;
+	}
+}

--- a/hawtio-springboot/src/main/java/io/hawt/springboot/PluginService.java
+++ b/hawtio-springboot/src/main/java/io/hawt/springboot/PluginService.java
@@ -1,0 +1,21 @@
+package io.hawt.springboot;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PluginService {
+
+	@Autowired
+	List<HawtPlugin> registeredPlugins;
+
+	@RequestMapping("/plugin")
+	public @ResponseBody List<HawtPlugin> getPlugins() {
+		return registeredPlugins;
+	}
+
+}


### PR DESCRIPTION
Not sure if this is a direction you want to take or not, but this represents how we are using hawtio with Spring Boot. We wanted to be able to package hawtio inside the application, rather than using the javaagent or the executable war options. This makes packaging and creation of plugins easier (for us).

This change creates a new jar, which is just a repackaging of the web war, moving all the static content to a /static/hawtio directory, which is a directory that will automatically be served by a Spring boot application when this jar is on the classpath of a Spring Boot application (anything under /static/\* is served by default). The jar also brings in as a dependency any necessary jars to make this work.

The other changes are:
1) Create a simple mechanism for registering custom plugins
2) Creating a plugin rest endpoint, so that custom plugins can be found by hawt
3) Disable the html5mode so that server rewrites don't need to be configured
4) Modified the existing Spring boot sample to demonstrate usage

When running the Spring boot sample application, hawt will be accessible at http://localhost:10000/hawtio/index.html
