### PR TITLE
Filter out 'undefined' methods from hawtioShow

### DIFF
--- a/hawtio-web/src/main/webapp/app/core/js/workspace.ts
+++ b/hawtio-web/src/main/webapp/app/core/js/workspace.ts
@@ -715,7 +715,8 @@ module Core {
       return true;
     }
 
-    public hasInvokeRights(selection:Core.NodeSelection, ...methods:Array<string>) {
+    public hasInvokeRights(selection:Core.NodeSelection, ...methods:Array<Object>) {
+      methods = methods.filter((m) => m !== undefined);
       var canInvoke = true;
       if (selection) {
         var selectionFolder = <Core.Folder> selection;


### PR DESCRIPTION
## InvokeRights

Firstly, this pull request _sucks_ as it stands, I'm just pushing it to get feedback.

I tried to catch up fabric8 with hawtio 1.4.26 because I am really interested in getting fabric8io/fabric8:#2780 properly fixed. To do that either #1657 needs to backported or fabric8 needs to catch up. I choose the latter (because I'm sure you would too ;-) ).

So I tried building fabric8 1.2.0-SNAPSHOT #b1c51d4 against the latest master of hawtio.

The result was, I get a load of 'Error: method is undefined' when opening the wiki page.

This seems to be caused by the RBAC (not sure what that means!) code calling [hasInvokeRights](https://github.com/zenlambda/hawtio/blob/mbean-only-rbac-invoke-rights/hawtio-web/src/main/webapp/app/rbac/js/hawtioRbacDirectives.ts#L84-84) when its dealing with an [MBEAN_ONLY](https://github.com/zenlambda/hawtio/blob/mbean-only-rbac-invoke-rights/hawtio-web/src/main/webapp/app/rbac/js/hawtioRbacDirectives.ts#L27-27) MBean. The [preceding logic](https://github.com/zenlambda/hawtio/blob/mbean-only-rbac-invoke-rights/hawtio-web/src/main/webapp/app/rbac/js/hawtioRbacDirectives.ts#L79) will stuff an 'undefined' method in the array, which this [guard condition](https://github.com/zenlambda/hawtio/blob/mbean-only-rbac-invoke-rights/hawtio-web/src/main/webapp/app/core/js/workspace.ts#L728-728) clearly doesn't expect.

This isn't serious fix, as is, because we should probably prevent the method being called with methods = [undefined] in the first place. But I figured it was good to push to get comments and feedback.
## Other stuff I can report:
### Error retrieving Summary.md

There seems to be some issue fetching Summary.md when you display a given profile that has one.

```
    HTTP ERROR 500

    Problem accessing /hawtio/git/1.0/fabric/profiles/kubernetes.profile/Summary.md. Reason:

        Server Error

    Caused by:

    javax.servlet.ServletException: No GitFacade object available!
        at io.hawt.web.GitServlet.doGet(GitServlet.java:50)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:575)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:668)
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:684)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1496)
        at io.hawt.web.XFrameOptionsFilter.doFilter(XFrameOptionsFilter.java:28)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1467)
        at io.hawt.web.CORSFilter.doFilter(CORSFilter.java:42)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1467)
        at io.hawt.web.CacheHeadersFilter.doFilter(CacheHeadersFilter.java:37)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1467)
        at io.hawt.web.SessionExpiryFilter.process(SessionExpiryFilter.java:144)
        at io.hawt.web.SessionExpiryFilter.doFilter(SessionExpiryFilter.java:47)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1467)
        at org.ops4j.pax.web.service.internal.WelcomeFilesFilter.doFilter(WelcomeFilesFilter.java:185)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1467)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:501)
        at org.ops4j.pax.web.service.jetty.internal.HttpServiceServletHandler.doHandle(HttpServiceServletHandler.java:69)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:137)
        at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:533)
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:231)
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1086)
        at org.ops4j.pax.web.service.jetty.internal.HttpServiceContext.doHandle(HttpServiceContext.java:240)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:429)
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:193)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1020)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:135)
        at org.ops4j.pax.web.service.jetty.internal.JettyServerHandlerCollection.handle(JettyServerHandlerCollection.java:77)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:116)
        at org.eclipse.jetty.server.Server.handle(Server.java:370)
        at org.eclipse.jetty.server.AbstractHttpConnection.handleRequest(AbstractHttpConnection.java:494)
        at org.eclipse.jetty.server.AbstractHttpConnection.headerComplete(AbstractHttpConnection.java:971)
        at org.eclipse.jetty.server.AbstractHttpConnection$RequestHandler.headerComplete(AbstractHttpConnection.java:1033)
        at org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:644)
        at org.eclipse.jetty.http.HttpParser.parseAvailable(HttpParser.java:235)
        at org.eclipse.jetty.server.AsyncHttpConnection.handle(AsyncHttpConnection.java:82)
        at org.eclipse.jetty.io.nio.SelectChannelEndPoint.handle(SelectChannelEndPoint.java:696)
        at org.eclipse.jetty.io.nio.SelectChannelEndPoint$1.run(SelectChannelEndPoint.java:53)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:608)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:543)
        at java.lang.Thread.run(Thread.java:745)

    Powered by Jetty://
```
### SVG icon reteival

Also it seems that where a profile has an svg icon it seems that it shall be displayed in the tree. Unfortunately this doesnt work as their is some problem retrieving the image.

Looking at other parts of the UI it seems that an svg can be retrieved when its icon is prefixed by '/cxf/fabric8/version' but not if its just 'git/'

```
git/1.0/fabric/profiles/containers/mule.ce.profile/icon.svg // DOES NOT WORK

/cxf/fabric8/version/1.0/profile/containers-mule.ce/overlay/file/icon.svg // DOES WORK
```

Hope this was helpful!
