### PR TITLE
Remove workspace fudge with proper fix to rbac

### DIFF
--- a/hawtio-web/src/main/webapp/app/core/js/workspace.ts
+++ b/hawtio-web/src/main/webapp/app/core/js/workspace.ts
@@ -715,8 +715,7 @@ module Core {
       return true;
     }
 
-    public hasInvokeRights(selection:Core.NodeSelection, ...methods:Array<Object>) {
-      methods = methods.filter((m) => m !== undefined);
+    public hasInvokeRights(selection:Core.NodeSelection, ...methods:Array<string>) {
       var canInvoke = true;
       if (selection) {
         var selectionFolder = <Core.Folder> selection;

--- a/hawtio-web/src/main/webapp/app/rbac/js/hawtioRbacDirectives.ts
+++ b/hawtio-web/src/main/webapp/app/rbac/js/hawtioRbacDirectives.ts
@@ -81,7 +81,12 @@ module RBAC {
           var mbean = Core.parseMBean(objectName);
           var folder = workspace.findMBeanWithProperties(mbean.domain, mbean.attributes);
           if (folder) {
-            var invokeRights = workspace.hasInvokeRights(folder, methodName);
+            var invokeRights;
+            if(methodName) {
+                invokeRights = workspace.hasInvokeRights(folder, methodName);
+            } else {
+                invokeRights = workspace.hasInvokeRights(folder);
+            }
             /*
             if (invokeRights) {
               log.debug("User has invoke rights on mbean: ", objectName, " methodName: ", methodName);


### PR DESCRIPTION
This IMHO a much better fix than the one I provided in PR: #1680. The fix seems obvious with hindsight. The RBAC code should not have been sending a possibly null/undefined method to the invokeRights method. Tested against recent snapshot (last weekend) of fabric8.

```
The RBAC code should not have be calling invokeRights
with an undefined method. Remove compensating code from
workspace file and fix the rbac code.
```
