### PR TITLE
ENTESB-2709 property keys are not displayed with correct color

### DIFF
--- a/hawtio-web/src/main/webapp/lib/codemirror/mode/properties/properties.js
+++ b/hawtio-web/src/main/webapp/lib/codemirror/mode/properties/properties.js
@@ -38,7 +38,7 @@ CodeMirror.defineMode("properties", function() {
         state.position = "quote";
         return null;
       } else if (ch === "\\" && state.position === "quote") {
-        if (stream.next() !== "u") {    // u = Unicode sequence \u1234
+        if (stream.next() === undefined) {  // end of line?
           // Multiline value
           state.nextMultiline = true;
         }


### PR DESCRIPTION
Codemirror was interpreting a backslash character anywhere in a line as a continuation character.