### PR TITLE
Fixes #1911: Creating new configurations with the hawtio-osgi-jmx plugin...

### DIFF
--- a/hawtio-osgi-jmx/src/main/java/io/hawt/osgi/jmx/ConfigAdmin.java
+++ b/hawtio-osgi-jmx/src/main/java/io/hawt/osgi/jmx/ConfigAdmin.java
@@ -48,7 +48,7 @@ public class ConfigAdmin implements ConfigAdminMXBean {
             if (ca == null) {
                 throw new IllegalStateException("The configuration admin service cannot be found.");
             }
-            Configuration config = ca.getConfiguration(pid);
+            Configuration config = ca.getConfiguration(pid, null);
             config.update(new Hashtable<String, String>(data));
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);

--- a/hawtio-osgi-jmx/src/test/java/io/hawt/osgi/jmx/ConfigAdminTest.java
+++ b/hawtio-osgi-jmx/src/test/java/io/hawt/osgi/jmx/ConfigAdminTest.java
@@ -16,7 +16,7 @@ public class ConfigAdminTest {
         Configuration conf = Mockito.mock(Configuration.class);        
 
         ConfigurationAdmin cas = Mockito.mock(ConfigurationAdmin.class);
-        Mockito.when(cas.getConfiguration("mypid")).thenReturn(conf);
+        Mockito.when(cas.getConfiguration("mypid", null)).thenReturn(conf);
 
         ServiceReference sr = Mockito.mock(ServiceReference.class);
 
@@ -32,7 +32,7 @@ public class ConfigAdminTest {
 
         ca.configAdminUpdate("mypid", props);
 
-        Mockito.verify(cas).getConfiguration("mypid");
+        Mockito.verify(cas).getConfiguration("mypid", null);
         Mockito.verify(conf).update(new Hashtable<String, String>(props));
     }
 }


### PR DESCRIPTION
... fails due to the default location on newly created pids being the hawtio-osgi-jmx bundle itself rather than null (any location)