### PR TITLE
ENTESB-2510 Filtering doesn't work on Containers view when profiles were...

### DIFF
--- a/hawtio-web/src/main/webapp/app/fabric/html/containerView.html
+++ b/hawtio-web/src/main/webapp/app/fabric/html/containerView.html
@@ -95,6 +95,7 @@
         <div>
           <div class="column-box" 
                ng-repeat="profile in version.profiles"
+               ng-show="filterProfiles(profile)"
                ng-include="'app/fabric/html/profileBox.html'">
           </div>
         </div>

--- a/hawtio-web/src/main/webapp/app/fabric/js/containerView.ts
+++ b/hawtio-web/src/main/webapp/app/fabric/js/containerView.ts
@@ -94,6 +94,10 @@ module Fabric {
       $scope.groupBy = 'none';
     }
 
+    $scope.filterProfiles = (profile) => {
+      return FilterHelpers.searchObject(profile.id, $scope.filter);
+    }
+
     $scope.filterContainers = (container) => {
       if (!Core.isBlank($scope.versionIdFilter) && container.versionId !== $scope.versionIdFilter) {
         return false;


### PR DESCRIPTION
... selected.  If you typed something in the filter box it applied it to containers, even if they were not displayed.  This PR adds filtering based on profile id.
