### PR TITLE
Check for null servlet context ConfigManager attribute

### DIFF
--- a/hawtio-system/src/main/java/io/hawt/web/UserServlet.java
+++ b/hawtio-system/src/main/java/io/hawt/web/UserServlet.java
@@ -22,7 +22,9 @@ public class UserServlet extends HttpServlet {
     @Override
     public void init(ServletConfig servletConfig) throws ServletException {
         config = (ConfigManager) servletConfig.getServletContext().getAttribute("ConfigManager");
-        this.authenticationEnabled = Boolean.parseBoolean(config.get("authenticationEnabled", "true"));
+        if (config != null) {
+            this.authenticationEnabled = Boolean.parseBoolean(config.get("authenticationEnabled", "true"));
+        }
 
         // JVM system properties can override always
         if (System.getProperty(AuthenticationFilter.HAWTIO_AUTHENTICATION_ENABLED) != null) {


### PR DESCRIPTION
You should check for a null ConfigManager before trying to access it to retrieve the 'authenticationEnabled' setting. In my environment (OSGi HTTP service), registering context parameters is disabled so the parameter will always be missing. This should not cause a NullPointerException when initializing the UserServlet.