### PR TITLE
Removed redirect from / since this will take over the root of the project.

### DIFF
--- a/hawtio-springboot/src/main/java/io/hawt/springboot/HawtioConfiguration.java
+++ b/hawtio-springboot/src/main/java/io/hawt/springboot/HawtioConfiguration.java
@@ -44,7 +44,6 @@ public class HawtioConfiguration extends WebMvcConfigurerAdapter {
 
     @Override
     public void addViewControllers(final ViewControllerRegistry registry) {
-        registry.addViewController("/").setViewName("redirect:/hawtio/index.html");
         registry.addViewController("/hawtio/plugin").setViewName("forward:/plugin");
         registry.addViewController("/hawtio/").setViewName("redirect:/hawtio/index.html");
     }


### PR DESCRIPTION
Removed the redirect from / to hawtio/index.html.

Spring boot users can add the registry.addViewController("/").setViewName("redirect:/hawtio/index.html"); in their own configuration if they need it. For most users this will only be a hassle if they do not want it.