### PR TITLE
[ENTESB-3844] host identification color in preferences is greyed out …

### DIFF
--- a/hawtio-web/src/main/webapp/app/themes/css/default.css
+++ b/hawtio-web/src/main/webapp/app/themes/css/default.css
@@ -653,7 +653,7 @@ div.hawtio-form-tabs ul.nav-tabs li.active a {
 }
 
 .color-picker div table tr td div {
-  border: 1px solid rgba(0, 0, 0, 0);
+  border: 3px solid rgba(0, 0, 0, 0);
   border-radius: 4px;
   box-shadow: 0 1px 10px rgba(0, 0, 0, 0.1);
 }
@@ -687,7 +687,6 @@ div.hawtio-form-tabs ul.nav-tabs li.active a {
 .selected, 
 .box.selected {
   color: normal;
-  background-color: #f0f0ff !important;
   text-shadow: none;
 }
 


### PR DESCRIPTION
…after selection.  @grgrzybek  or @gashcrumb  can you review this and merge if you think it's ok?  I ask because I removed the line marked "Important", but that's in fact the cause of the problem.

I increased the width of the border to 3px because at 1 or 2 the border tends to get lost with darker colors. 
