### PR TITLE
added button to create managed service from a factory

### DIFF
--- a/hawtio-web/src/main/webapp/app/osgi/html/configurations.html
+++ b/hawtio-web/src/main/webapp/app/osgi/html/configurations.html
@@ -46,7 +46,9 @@
   <ul class="configurations">
     <li ng-repeat='config in configurations | filter:filterText' class='{{config.class}} bundle-item'>
       <a ng-href="{{config.pidLink}}" title="{{config.description}}">
-        <span class="{{config.kind.class}}">{{config.name}}</span>
+        <span class="{{config.kind.class}}">{{config.name}}
+            <button class="btn btn-small" ng-if="config.isFactory" ng-click="createConfigInstance($event, config)"><i class="icon-plus"></i></button>
+        </span>
       </a>
       <ul ng-show="config.isFactory">
         <li ng-repeat="child in config.children" class='{{child.class}} bundle-item'>

--- a/hawtio-web/src/main/webapp/app/osgi/js/configurations.ts
+++ b/hawtio-web/src/main/webapp/app/osgi/js/configurations.ts
@@ -74,6 +74,24 @@ module Osgi {
       }
     };
 
+    $scope.createConfigInstance = ($event, config) => {
+        $event.preventDefault();
+        var mbean = getHawtioConfigAdminMBean(workspace);
+        if (mbean) {
+            var pidMBean = getSelectionConfigAdminMBean($scope.workspace);
+            $scope.jolokia.execute(pidMBean, "createFactoryConfiguration", config.pid, onSuccess((response) => {
+                var pid = response;
+                var json = JSON.stringify({});
+                $scope.jolokia.execute(mbean, "configAdminUpdate", pid, json, onSuccess((resp) => {
+                    Core.notification("success", "Successfully created pid: " + pid);
+                    updateTableContents();
+                }, errorHandler("Failed to create new PID: ")));
+
+            }, errorHandler("Failed to create new PID: ")));
+        }
+
+    };
+
     $scope.$on("$routeChangeSuccess", function (event, current, previous) {
       // lets do this asynchronously to avoid Error: $digest already in progress
       setTimeout(updateTableContents, 50);


### PR DESCRIPTION
This addresses issue #2014, in a rudimentary fashion.  The functionality is there to simply click a single button, and create a new managed service, with metatype information.