### PR TITLE
Fix for #2025, handle html5 deactivation for uglified JS

### DIFF
--- a/hawtio-springboot/pom.xml
+++ b/hawtio-springboot/pom.xml
@@ -105,8 +105,16 @@
 								<include>app/app.js</include>
 							</includes>
 							<encoding>ISO-8859-1</encoding>
-							<token>$locationProvider.html5Mode(true);</token>
-							<value>$locationProvider.html5Mode(false);</value>
+							<replacements>
+								<replacement>
+									<token>$locationProvider.html5Mode(true);</token>
+									<value>$locationProvider.html5Mode(false);</value>
+								</replacement>
+								<replacement>
+									<token>.html5Mode(!0)</token>
+									<value>.html5Mode(!!0)</value>
+								</replacement>
+							</replacements>
 							<regex>false</regex>
 							<quiet>false</quiet>
 						</configuration>


### PR DESCRIPTION
There is issue with replacing JS code after it was uglified, so release build does not do html5Mode switch for Spring boot and it fails to start properly. See issue https://github.com/hawtio/hawtio/issues/2025
