### PR TITLE
Remove System.out line

### DIFF
--- a/hawtio-git/src/main/java/io/hawt/git/GitFacade.java
+++ b/hawtio-git/src/main/java/io/hawt/git/GitFacade.java
@@ -742,7 +742,6 @@ public class GitFacade extends GitFacadeSupport {
                 LOG.warn("Failed to write git " + gitAttributes + ". " + e, e);
             }
         }
-        System.out.println("Importing initial URLs: " + initialImportURLs);
         if (Strings.isNotBlank(initialImportURLs)) {
             String[] split = initialImportURLs.split(",");
             if (split != null) {


### PR DESCRIPTION
Remove the System.out.println line. It easily adds up if you use many GitFacade objects.