### PR TITLE
Gitective jgit upgrade and switch to jdk 1.8

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   node:
     version: 0.10.33
+  java:
+    version: oraclejdk8
   services:
 
 branches:

--- a/hawtio-git/pom.xml
+++ b/hawtio-git/pom.xml
@@ -71,7 +71,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.gitective</groupId>
+      <groupId>io.fabric8</groupId>
       <artifactId>gitective-core</artifactId>
       <version>${gitective-version}</version>
       <exclusions>

--- a/hawtio-git/src/main/java/io/hawt/git/GitFacadeSupport.java
+++ b/hawtio-git/src/main/java/io/hawt/git/GitFacadeSupport.java
@@ -189,7 +189,7 @@ public abstract class GitFacadeSupport extends MBeanSupport implements GitFacade
                         list.add(new CommitTreeInfo(pathString, pathString, 0, rawMode, objectId.getName(), commit.getId().getName(),
                                 ChangeType.ADD));
                     }
-                    treeWalk.release();
+                    treeWalk.close();
                 } else {
                     RevCommit parent = rw.parseCommit(commit.getParent(0).getId());
                     DiffFormatter df = new DiffFormatter(DisabledOutputStream.INSTANCE);

--- a/hawtio-sample-springboot-authentication/pom.xml
+++ b/hawtio-sample-springboot-authentication/pom.xml
@@ -15,7 +15,6 @@
     <packaging>war</packaging>
 
     <properties>
-        <start-class>io.hawt.sample.spring.boot.SampleAuthenticationSpringBootService</start-class>
         <!-- Jetty version referred from the spring-boot-dependencies project -->
         <jetty.version>9.2.11.v20150529</jetty.version>
     </properties>
@@ -70,6 +69,9 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring-boot-version}</version>
+                <configuration> 
+                    <mainClass>io.hawt.sample.spring.boot.SampleAuthenticationSpringBootService</mainClass>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/hawtio-sample-springboot/pom.xml
+++ b/hawtio-sample-springboot/pom.xml
@@ -14,10 +14,6 @@
     <description>hawtio :: Sample Spring Boot process</description>
     <packaging>war</packaging>
 
-    <properties>
-        <start-class>io.hawt.sample.spring.boot.SampleSpringBootService</start-class>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -47,6 +43,9 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring-boot-version}</version>
+                <configuration>
+                    <mainClass>io.hawt.sample.spring.boot.SampleSpringBootService</mainClass>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/hawtio-system/pom.xml
+++ b/hawtio-system/pom.xml
@@ -39,7 +39,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.gitective</groupId>
+      <groupId>io.fabric8</groupId>
       <artifactId>gitective-core</artifactId>
       <version>${gitective-version}</version>
       <exclusions>

--- a/hawtio-web/pom.xml
+++ b/hawtio-web/pom.xml
@@ -329,7 +329,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.gitective</groupId>
+      <groupId>io.fabric8</groupId>
       <artifactId>gitective-core</artifactId>
       <version>${gitective-version}</version>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
     <context>/hawtio</context>
     <hawtio-config-dir>${basedir}/hawtio-config</hawtio-config-dir>
     <hawtio-config-repo>https://github.com/hawtio/hawtio-config.git</hawtio-config-repo>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
 
     <webapp-dir>${project.artifactId}-${project.version}</webapp-dir>
     <webapp-outdir>${basedir}/target/${webapp-dir}</webapp-outdir>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <exec-maven-plugin-version>1.4.0</exec-maven-plugin-version>
     <felix.gogo.version>0.16.2</felix.gogo.version>
     <frontend-maven-plugin-version>0.0.24</frontend-maven-plugin-version>
-    <gitective-version>0.9.9</gitective-version>
+    <gitective-version>0.9.10</gitective-version>
 
     <!-- We are using an old guava to avoid breaking ActiveMQ in the test cases of hawtio-web -->
     <!--
@@ -112,7 +112,7 @@
     <jetty-plugin-version>${jetty-version}</jetty-plugin-version>
     <jetty-webapp-artifactId>jetty-webapp</jetty-webapp-artifactId>
 
-    <jgit-version>3.0.0.201306101825-r</jgit-version>
+    <jgit-version>4.1.1.201511131810-r</jgit-version>
     <jline.version>2.13</jline.version>
     <jolokia-version>1.3.2</jolokia-version>
     <junit-version>4.11</junit-version>


### PR DESCRIPTION
- Upgrade to Fabric8 gitective 0.9.10
- Upgrade Jgit to latest version
- Switch to JDK 1.8
- Aligned Springboot samples with mainClass configuration property.

Andrea