### PR TITLE
Addresses ticket #1965

### DIFF
--- a/hawtio-web/src/main/webapp/app/jvm/js/connect.ts
+++ b/hawtio-web/src/main/webapp/app/jvm/js/connect.ts
@@ -159,6 +159,21 @@ module JVM {
       angular.extend($scope.currentConfig, $scope.connectionConfigs[$scope.lastConnection]);
       Core.$apply($scope);
     };
+    
+	var autoconnect = $location.search();
+	if (typeof autoconnect != 'undefined' && typeof autoconnect.name != 'undefined') {	
+		var conOpts = Core.createConnectOptions({
+		        scheme: 'http',
+		        host: autoconnect.host,
+		        path: autoconnect.path,
+		        port: autoconnect.port,
+		        userName: autoconnect.userName,
+		        password: autoconnect.password,
+		        name: autoconnect.name
+		});			
+	    $scope.gotoServer(conOpts,null,false);	
+		window.close();
+	}
 
   }]);
 }


### PR DESCRIPTION
I am planing on integrating hawtio into a monitoring application we have and wanted the ability to create links that would open up hawtio and automatically connect to specific servers being monitored.

With this change I am able to do so by creating links in this format
/hawtio/index.html#/jvm/connect?name={name}&host={host}&port={port}&path={path}&userName={userName}&password={password}

This is very hacky and I am sure one of you could improve it, I have only started looking at hawtio today and javascript/typescrypt is not something I am too familiar with.