### PR TITLE
Mark classes in hawtio-insight-log that are marshaled over jmx as serializable

### DIFF
--- a/hawtio-insight-log/src/main/java/io/hawt/log/LogEvent.java
+++ b/hawtio-insight-log/src/main/java/io/hawt/log/LogEvent.java
@@ -3,11 +3,13 @@ package io.hawt.log;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.hawt.log.support.Objects;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class LogEvent implements Comparable<LogEvent> {
+public class LogEvent implements Comparable<LogEvent>, Serializable {
+    private static final long serialVersionUID = 1L;
     private static String defaultContainerName;
 
 	private String host;

--- a/hawtio-insight-log/src/main/java/io/hawt/log/LogFilter.java
+++ b/hawtio-insight-log/src/main/java/io/hawt/log/LogFilter.java
@@ -1,11 +1,13 @@
 package io.hawt.log;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-public class LogFilter {
+public class LogFilter implements Serializable {
+    private static final long serialVersionUID = 1L;
     private int count;
     private String[] levels;
     private String matchesText;

--- a/hawtio-insight-log/src/main/java/io/hawt/log/LogResults.java
+++ b/hawtio-insight-log/src/main/java/io/hawt/log/LogResults.java
@@ -1,12 +1,14 @@
 package io.hawt.log;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Results of a query which also records the first and last timestamp searched
  */
-public class LogResults {
+public class LogResults implements Serializable {
+    private static final long serialVersionUID = 1L;
     private List<LogEvent> events;
     private Long fromTimestamp;
     private Long toTimestamp;


### PR DESCRIPTION
- LogResults, LogFilter and LogEvent marked as serializable

We need the classes in hawtio-insight-log to be marked serializable, as we use a multi-tier application architecture where the "web tier" runs hawtio, but back-end services do not install the http feature, nor do they install jolokia.  In this case, we use federation provided by the legacy jdmk to marshal instance data over rmi (jmx bridging).  Because of this, installing hub/spoke log monitoring doesn't work, and we have to cobble together a delegation model using openmbeans.

Alternately, marking this class as @MXBean would work and not require each tier to have the classes installed.   This change simply marks the beans serializable.