### PR TITLE
ENTESB-4996 - Fix ClassCastException with overloaded methods in RBACDecorator

### DIFF
--- a/hawtio-osgi-jmx/src/test/java/io/hawt/osgi/jmx/RBACDecoratorTest.java
+++ b/hawtio-osgi-jmx/src/test/java/io/hawt/osgi/jmx/RBACDecoratorTest.java
@@ -182,12 +182,15 @@ public class RBACDecoratorTest {
         assertThat(mbean.get("canInvoke"), equalTo((Object) false));
 
         // op
-        Map<String, Map<String, Object>> op = (Map<String, Map<String, Object>>) mbean.get("op");
+        Map<String, Object> op = (Map<String, Object>) mbean.get("op");
         LOG.info("op = {}", op);
-        assertThat(op.get("removeQueue").get("canInvoke"), equalTo((Object) false));
-        assertThat(op.get("addQueue").get("canInvoke"), equalTo((Object) false));
-        assertThat(op.get("stop").get("canInvoke"), equalTo((Object) true));
-        assertThat(op.get("start").get("canInvoke"), equalTo((Object) true));
+        assertThat(((Map<String, Object>) op.get("removeQueue")).get("canInvoke"), equalTo((Object) false));
+        assertThat(((Map<String, Object>) op.get("addQueue")).get("canInvoke"), equalTo((Object) false));
+        assertThat(((Map<String, Object>) op.get("stop")).get("canInvoke"), equalTo((Object) true));
+        assertThat(((Map<String, Object>) op.get("start")).get("canInvoke"), equalTo((Object) true));
+        assertThat(((List<Map<String, Object>>) op.get("overloadedMethod")).get(0).get("canInvoke"), equalTo((Object) true));
+        assertThat(((List<Map<String, Object>>) op.get("overloadedMethod")).get(1).get("canInvoke"), equalTo((Object) false));
+        assertThat(((List<Map<String, Object>>) op.get("overloadedMethod")).get(2).get("canInvoke"), equalTo((Object) true));
 
         // opByString
         Map<String, Map<String, Boolean>> opByString = (Map<String, Map<String, Boolean>>) mbean.get("opByString");
@@ -197,11 +200,17 @@ public class RBACDecoratorTest {
                 "removeQueue(java.lang.String)",
                 "addQueue(java.lang.String)",
                 "stop()",
-                "start()"));
+                "start()",
+                "overloadedMethod(java.lang.String)",
+                "overloadedMethod(java.lang.String,java.lang.Object)",
+                "overloadedMethod()"));
         assertThat(opByString.get("removeQueue(java.lang.String)").get("canInvoke"), equalTo(false));
         assertThat(opByString.get("addQueue(java.lang.String)").get("canInvoke"), equalTo(false));
         assertThat(opByString.get("stop()").get("canInvoke"), equalTo(true));
         assertThat(opByString.get("start()").get("canInvoke"), equalTo(true));
+        assertThat(opByString.get("overloadedMethod(java.lang.String)").get("canInvoke"), equalTo(true));
+        assertThat(opByString.get("overloadedMethod(java.lang.String,java.lang.Object)").get("canInvoke"), equalTo(false));
+        assertThat(opByString.get("overloadedMethod()").get("canInvoke"), equalTo(true));
     }
 
     @SuppressWarnings("unchecked")
@@ -229,7 +238,9 @@ public class RBACDecoratorTest {
         CompositeData cdForMBeanOps = mock(CompositeData.class);
         when((Collection<CompositeData>) td.values()).thenReturn(
                 Arrays.asList(cdForMBeans),
-                Arrays.asList(cdForMBeanOps, cdForMBeanOps, cdForMBeanOps, cdForMBeanOps));
+                Arrays.asList(
+                        cdForMBeanOps, cdForMBeanOps, cdForMBeanOps, cdForMBeanOps,
+                        cdForMBeanOps, cdForMBeanOps, cdForMBeanOps));
         when(cdForMBeans.get("ObjectName")).thenReturn("org.apache.activemq:type=Broker,brokerName=amq");
         when(cdForMBeans.get("CanInvoke")).thenReturn(false);
         when(cdForMBeanOps.get("ObjectName")).thenReturn("org.apache.activemq:type=Broker,brokerName=amq");
@@ -237,15 +248,20 @@ public class RBACDecoratorTest {
                 "removeQueue(java.lang.String)",
                 "addQueue(java.lang.String)",
                 "stop()",
-                "start()");
+                "start()",
+                "overloadedMethod(java.lang.String)",
+                "overloadedMethod(java.lang.String,java.lang.Object)",
+                "overloadedMethod()");
         // invoked two times for each cd
         when(cdForMBeanOps.get("CanInvoke")).thenReturn(
                 false, false,
                 false, false,
                 true, true,
+                true, true,
+                true, true,
+                false, false,
                 true, true);
 
         return bc;
     }
-
 }

--- a/hawtio-osgi-jmx/src/test/resources/io/hawt/osgi/jmx/RBACDecoratorTest-input.json
+++ b/hawtio-osgi-jmx/src/test/resources/io/hawt/osgi/jmx/RBACDecoratorTest-input.json
@@ -36,7 +36,41 @@
             "args": [],
             "desc": "Operation exposed for management",
             "ret": "void"
-          }
+          },
+          "overloadedMethod": [
+            {
+              "args": [
+                {
+                  "type": "java.lang.String",
+                  "name": "arg1",
+                  "desc": ""
+                }
+              ],
+              "desc": "Dummy method 1 for testing method overloading",
+              "ret": "java.lang.String"
+            },
+            {
+              "args": [
+                {
+                  "type": "java.lang.String",
+                  "name": "arg1",
+                  "desc": ""
+                },
+                {
+                  "type": "java.lang.Object",
+                  "name": "arg2",
+                  "desc": ""
+                }
+              ],
+              "desc": "Dummy method 2 for testing method overloading",
+              "ret": "java.lang.String"
+            },
+            {
+              "args": [],
+              "desc": "Dummy method 3 for testing method overloading",
+              "ret": "java.lang.String"
+            }
+          ]
         },
         "desc": "Information on the management interface of the MBean",
         "not": {}


### PR DESCRIPTION
The previous fix causes the following `ClassCastException` in the presence of overloaded methods:
```
| ERROR | qtp1069006536-85 | RBACDecorator                    | 204 - io.hawt.hawtio-osgi-jmx - 1.4.0.redhat-630-SNAPSHOT | java.util.LinkedList cannot be cast to java.util.Map
java.lang.ClassCastException: java.util.LinkedList cannot be cast to java.util.Map
	at io.hawt.osgi.jmx.RBACDecorator.decorate(RBACDecorator.java:203)
```