### PR TITLE
ENTESB-5479 - Added support for externalized jolokia-access.xml config

### DIFF
--- a/hawtio-system/src/main/java/io/hawt/web/JolokiaConfiguredAgentServlet.java
+++ b/hawtio-system/src/main/java/io/hawt/web/JolokiaConfiguredAgentServlet.java
@@ -1,0 +1,94 @@
+package io.hawt.web;
+import org.jolokia.config.ConfigKey;
+import org.jolokia.http.AgentServlet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import java.util.Enumeration;
+import java.util.Hashtable;
+
+public class JolokiaConfiguredAgentServlet extends AgentServlet{
+    private static final transient Logger LOG = LoggerFactory.getLogger(JolokiaConfiguredAgentServlet.class);
+
+    @Override
+    public void init(ServletConfig pServletConfig) throws ServletException {
+
+        String policyLocation = System.getProperty("jolokia." + ConfigKey.POLICY_LOCATION.toString() );
+        if(policyLocation != null){
+            LOG.info("Jolokia will load jolokia-access.xml from [" + policyLocation + "]");
+            ServletConfigWrapper pServletConfigWrapper = new  ServletConfigWrapper(pServletConfig);
+            pServletConfigWrapper.addProperty(ConfigKey.POLICY_LOCATION.toString(), policyLocation);
+            super.init(pServletConfigWrapper);
+
+        } else{
+            LOG.info("Jolokia has not found any jolokia-access.xml configured with " + "jolokia." + ConfigKey.POLICY_LOCATION.toString() + " ; Default configuration values will be used.");
+            super.init(pServletConfig);
+        }
+
+    }
+
+    class ServletConfigWrapper implements ServletConfig {
+        ServletConfig wrapped;
+        Hashtable<String,String> ownProps;
+
+        public ServletConfigWrapper(ServletConfig pServletConfig){
+            wrapped = pServletConfig;
+            ownProps = new Hashtable<>();
+        }
+
+        @Override
+        public String getServletName() {
+            return wrapped.getServletName();
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            return wrapped.getServletContext();
+        }
+
+        @Override
+        public String getInitParameter(String s) {
+            if(ownProps.containsKey(s)){
+                return ownProps.get(s);
+            }
+            return wrapped.getInitParameter(s);
+        }
+
+        @Override
+        public Enumeration getInitParameterNames() {
+            return new TwoEnumerationsWrapper(ownProps.keys(), wrapped.getInitParameterNames());
+        }
+
+        public void addProperty(String key, String value){
+            ownProps.put(key, value);
+        }
+    }
+
+    class TwoEnumerationsWrapper implements Enumeration<String>{
+        Enumeration<String>  a;
+        Enumeration<String>  b;
+
+        public TwoEnumerationsWrapper(Enumeration a, Enumeration b){
+            this.a = a;
+            this.b = b;
+        }
+
+        @Override
+        public boolean hasMoreElements() {
+            return a.hasMoreElements() || b.hasMoreElements();
+        }
+
+        @Override
+        public String nextElement() {
+            if(a.hasMoreElements()){
+                return a.nextElement();
+            } else{
+                return b.nextElement();
+            }
+        }
+    }
+
+}

--- a/hawtio-web/src/main/webapp/WEB-INF/web.xml
+++ b/hawtio-web/src/main/webapp/WEB-INF/web.xml
@@ -161,7 +161,7 @@
 
   <servlet>
     <servlet-name>jolokia-agent</servlet-name>
-    <servlet-class>org.jolokia.http.AgentServlet</servlet-class>
+    <servlet-class>io.hawt.web.JolokiaConfiguredAgentServlet</servlet-class>
     <init-param>
       <param-name>mbeanQualifier</param-name>
       <param-value>qualifier=hawtio</param-value>


### PR DESCRIPTION
It uses now a system property.

ex.
```
EXTRA_JAVA_OPTS='-Djolokia.policyLocation=file:///home/fuse/my-access.xml' bin/fuse debug
```

Fixes #2139 