### PR TITLE
Fix #2146 RBAC with optimised Jolokia call doesn't work on Karaf

### DIFF
--- a/hawtio-karaf/src/main/resources/features.xml
+++ b/hawtio-karaf/src/main/resources/features.xml
@@ -13,6 +13,11 @@
 
   </feature>
 
+  <feature name="hawtio-rbac" version="${project.version}" resolver="(obr)">
+    <details>Installs the hawtio RBAC enabler bundle(s)</details>
+    <bundle>mvn:io.hawt/hawtio-osgi-jmx/${project.version}</bundle>
+  </feature>
+
   <feature name="hawtio-log" version="${project.version}" resolver="(obr)">
     <details>Installs the hawtio logging</details>
     <bundle>mvn:io.hawt/hawtio-insight-log/${project.version}</bundle>
@@ -25,6 +30,7 @@
   <feature name="hawtio" version="${project.version}" resolver="(obr)">
     <details>Installs the main hawtio web console</details>
     <feature>hawtio-core</feature>
+    <feature>hawtio-rbac</feature>
     <feature>hawtio-log</feature>
     <feature>hawtio-karaf-terminal</feature>
     <feature>hawtio-maven-indexer</feature>

--- a/hawtio-osgi-jmx/pom.xml
+++ b/hawtio-osgi-jmx/pom.xml
@@ -100,6 +100,10 @@
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Activator>io.hawt.osgi.jmx.Activator</Bundle-Activator>
             <Bundle-Description>Additional JMX APIs into the OSGi Framework, used by hawt.io browser-based client.</Bundle-Description>
+            <Import-Package>
+              org.apache.karaf.management;version="${karaf-version-range}",
+              *
+            </Import-Package>
             <Export-Package />
             <Private-Package>org.apache.commons.codec*,io.hawt.osgi.jmx</Private-Package>
           </instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
     <jolokia-version>1.3.3</jolokia-version>
     <junit-version>4.11</junit-version>
     <karaf-version>4.0.4</karaf-version>
+    <karaf-version-range>[3.0,5)</karaf-version-range>
     <log4j-version>1.2.17</log4j-version>
     <maven-version>3.0.4</maven-version>
     <maven-antrun-plugin-version>1.7</maven-antrun-plugin-version>


### PR DESCRIPTION
Now for Karaf 4.x:
```
feature:repo-add hawtio <version>
feature:install hawtio
```
installs `hawtio-osgi-jmx` bundle as well. For Karaf 3.x, you need:
```
feature:repo-add hawtio <version>
feature:install hawtio-core
feature:install hawtio-rbac
```
For Karaf 2.x RBAC is not supported since RBAC is introduced to Karaf since 3.0.