### PR TITLE
Pull Request for #2075

### DIFF
--- a/hawtio-web/src/main/webapp/app/activemq/js/activemqPlugin.ts
+++ b/hawtio-web/src/main/webapp/app/activemq/js/activemqPlugin.ts
@@ -39,6 +39,31 @@ module ActiveMQ {
 
     workspace.addTreePostProcessor(postProcessTree);
 
+    var onClickRowHandlers = workspace.onClickRowHandlers;
+
+    var onClickFunction = (row)  => {
+      var entityName = row.entity.Name;
+      var treeElement = $("#activemqtree");
+      if(treeElement.length === 0)
+      { // We are on the JMX Plugin Tree view
+        treeElement = $("#jmxtree")
+      }
+      if(treeElement.length != 0) {
+        var root = <any>treeElement.dynatree("getActiveNode");
+        var children = root.getChildren();
+        for (var idx in children){
+          if(children[idx] && children[idx].data.title === entityName ){
+            children[idx].expand(true);
+            children[idx].activate();
+            break;
+          }
+        }
+      }
+    };
+
+    onClickRowHandlers[jmxDomain + "/Queue/folder"] = onClickFunction;
+    onClickRowHandlers[jmxDomain + "/Topic/folder"] = onClickFunction;
+
     // register default attribute views
     var attributes = workspace.attributeColumnDefs;
     attributes[jmxDomain + "/Broker/folder"] = [

--- a/hawtio-web/src/main/webapp/app/camel/js/camelPlugin.ts
+++ b/hawtio-web/src/main/webapp/app/camel/js/camelPlugin.ts
@@ -102,6 +102,53 @@ module Camel {
       // we do not want to default sort the state column
     };
 
+    var onClickHandlers = workspace.onClickRowHandlers;
+
+    function goToEntityInTree(entityName) {
+      var treeElement = $("#cameltree");
+      if (treeElement.length === 0) { // We are on the JMX Plugin Tree view
+        treeElement = $("#jmxtree")
+      }
+      if (treeElement.length != 0) {
+        var root = <any>treeElement.dynatree("getActiveNode");
+        var children = root.getChildren();
+        for (var idx in children) {
+          if (children[idx] && children[idx].data.title === entityName) {
+            children[idx].expand(true);
+            children[idx].activate();
+            break;
+          }
+        }
+      }
+    }
+
+    onClickHandlers[camelJmxDomain + "/context/folder"] =
+        (row) => {
+          var entityName = row.entity.CamelId;
+          goToEntityInTree(entityName);
+        };
+
+    onClickHandlers[camelJmxDomain + "/routes/folder"] =
+        (row) => {
+          var entityName = row.entity.RouteId;
+          goToEntityInTree(entityName);
+        };
+
+    onClickHandlers[camelJmxDomain + "/endpoints/folder"] =
+        (row) => {
+          var entityName = row.entity.EndpointUri;
+          //TODO there might be a better way to match the URL with the title in the tree
+          entityName = entityName.replace('?', '\\?');
+          goToEntityInTree(entityName);
+        };
+
+    onClickHandlers[camelJmxDomain + "/components/folder"] = (row) => {
+      var entityName = row.entity.ComponentName;
+      goToEntityInTree(entityName);
+    };
+
+
+
     var attributes = workspace.attributeColumnDefs;
     attributes[camelJmxDomain + "/context/folder"] = [
       stateColumn,

--- a/hawtio-web/src/main/webapp/app/core/js/workspace.ts
+++ b/hawtio-web/src/main/webapp/app/core/js/workspace.ts
@@ -32,6 +32,7 @@ module Core {
     public mbeanTypesToDomain = {};
     public mbeanServicesToDomain = {};
     public attributeColumnDefs = {};
+    public onClickRowHandlers = {};
     public treePostProcessors = [];
     public topLevelTabs = <Array<NavMenuItem>>[];
     public subLevelTabs = [];

--- a/hawtio-web/src/main/webapp/app/datatable/js/simpleDataTable.ts
+++ b/hawtio-web/src/main/webapp/app/datatable/js/simpleDataTable.ts
@@ -239,6 +239,16 @@ module DataTable {
         return (row) && config.selectedItems.some(row.entity);
       };
 
+      $scope.onRowClicked = (row) => {
+        var id = $scope.config.gridKey;
+        if(id){
+            var func = $scope.config.onClickRowHandlers[id];
+            if(func) {
+                func(row);
+            }
+        }
+      };
+
       $scope.onRowSelected = (row) => {
         var idx = config.selectedItems.indexOf(row.entity);
         if (idx >= 0) {
@@ -270,7 +280,7 @@ module DataTable {
       }
       var headHtml = "<thead><tr>";
       // use a function to check if a row is selected so the UI can be kept up to date asap
-      var bodyHtml = "<tbody><tr ng-repeat='row in rows track by $index' ng-show='showRow(row)' " + onMouseDown + "ng-class=\"{'selected': isSelected(row)}\" >";
+      var bodyHtml = "<tbody><tr ng-repeat='row in rows track by $index' ng-show='showRow(row)' ng-click='onRowClicked(row)'" + onMouseDown + "ng-class=\"{'selected': isSelected(row)}\" >";
       var idx = 0;
       if (showCheckBox) {
         var toggleAllHtml = isMultiSelect() ?

--- a/hawtio-web/src/main/webapp/app/jmx/js/attributes.ts
+++ b/hawtio-web/src/main/webapp/app/jmx/js/attributes.ts
@@ -537,7 +537,10 @@ module Jmx {
 
             if (!$scope.gridOptions.columnDefs.length) {
               // lets update the column definitions based on any configured defaults
+
               var key = workspace.selectionConfigKey();
+              $scope.gridOptions.gridKey = key;
+              $scope.gridOptions.onClickRowHandlers = workspace.onClickRowHandlers;
               var defaultDefs = workspace.attributeColumnDefs[key] || [];
               var defaultSize = defaultDefs.length;
               var map = {};


### PR DESCRIPTION
The idea is that each plugin can register onClickHandler on specific table the same way they are declaring columns and then when a click event happend the hawtio-simple-table will propagate it to the plugin. This is used to fix issue #2075  for ActiveMQ and also for Camel plugin for routes/components/endpoints/context 