### PR TITLE
ENTESB-5736 - open hawtio tab in new tab/windows produces RBACRestrictor error javax.management.InstanceNotFoundException

### DIFF
--- a/hawtio-system/src/main/java/io/hawt/web/RBACRestrictor.java
+++ b/hawtio-system/src/main/java/io/hawt/web/RBACRestrictor.java
@@ -27,7 +27,9 @@ import org.jolokia.util.RequestType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.management.InstanceNotFoundException;
 import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanException;
 import javax.management.MBeanInfo;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
@@ -140,7 +142,18 @@ public class RBACRestrictor implements Restrictor {
             params = new Object[] { objectName.getCanonicalName(), opName, argTypes.toArray(new String[0]) };
             signature = new String[] { String.class.getName(), String.class.getName(), String[].class.getName() };
         }
-        return (boolean) mBeanServer.invoke(securityMBean, "canInvoke", params, signature);
+        try {
+            return (boolean) mBeanServer.invoke(securityMBean, "canInvoke", params, signature);
+        } catch (InstanceNotFoundException e) {
+            LOG.info("Instance not found: {}", e.getMessage());
+            return false;
+        } catch (MBeanException e) {
+            if (e.getCause() instanceof InstanceNotFoundException) {
+                LOG.info("Instance not found: {}", e.getCause().getMessage());
+                return false;
+            }
+            throw e;
+        }
     }
 
     private String parseOperation(String operation, List<String> argTypes) {

--- a/hawtio-system/src/test/java/io/hawt/web/RBACRestrictorTest.java
+++ b/hawtio-system/src/test/java/io/hawt/web/RBACRestrictorTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.management.InstanceNotFoundException;
 import javax.management.ObjectName;
 import java.util.Arrays;
 
@@ -64,6 +65,7 @@ public class RBACRestrictorTest {
         assertThat(restrictor.isOperationAllowed(new ObjectName("hawtio:type=Test"), "allowed()"), is(true));
         assertThat(restrictor.isOperationAllowed(new ObjectName("hawtio:type=Test"), "notAllowed()"), is(false));
         assertThat(restrictor.isOperationAllowed(new ObjectName("hawtio:type=Test"), "error()"), is(false));
+        assertThat(restrictor.isOperationAllowed(new ObjectName("hawtio:type=NoSuchType"), "noInstance()"), is(false));
 
         assertThat(restrictor.isOperationAllowed(new ObjectName("hawtio:type=Test"), "allowed(boolean,long,java.lang.String)"), is(true));
         assertThat(restrictor.isOperationAllowed(new ObjectName("hawtio:type=Test"), "notAllowed(boolean,long,java.lang.String)"), is(false));
@@ -95,6 +97,9 @@ public class RBACRestrictorTest {
             }
             if ("hawtio:type=Test".equals(objectName) && "error".equals(methodName)) {
                 throw new Exception();
+            }
+            if ("hawtio:type=NoSuchType".equals(objectName) && "noInstance".equals(methodName)) {
+                throw new InstanceNotFoundException(objectName);
             }
             if ("java.lang:type=Runtime".equals(objectName) && "getVmName".equals(methodName)) {
                 return true;


### PR DESCRIPTION
Write `InstanceNotFoundException` to `INFO` log instead of `ERROR` as sometimes non-existent
MBeans may be invoked intentionally to probe if a component is available.