### PR TITLE
ENTESB-5219 - Make RBACRestrictor always use canInvoke(String, String, String[])

### DIFF
--- a/hawtio-system/src/main/java/io/hawt/web/RBACRestrictor.java
+++ b/hawtio-system/src/main/java/io/hawt/web/RBACRestrictor.java
@@ -133,15 +133,8 @@ public class RBACRestrictor implements Restrictor {
         }
         List<String> argTypes = new ArrayList<>();
         String opName = parseOperation(operation, argTypes);
-        Object[] params;
-        String[] signature;
-        if (argTypes.isEmpty()) {
-            params = new Object[] { objectName.getCanonicalName(), opName };
-            signature = new String[] { String.class.getName(), String.class.getName() };
-        } else {
-            params = new Object[] { objectName.getCanonicalName(), opName, argTypes.toArray(new String[0]) };
-            signature = new String[] { String.class.getName(), String.class.getName(), String[].class.getName() };
-        }
+        Object[] params = new Object[] { objectName.getCanonicalName(), opName, argTypes.toArray(new String[0]) };
+        String[] signature = new String[] { String.class.getName(), String.class.getName(), String[].class.getName() };
         try {
             return (boolean) mBeanServer.invoke(securityMBean, "canInvoke", params, signature);
         } catch (InstanceNotFoundException e) {

--- a/hawtio-system/src/test/java/io/hawt/web/RBACRestrictorTest.java
+++ b/hawtio-system/src/test/java/io/hawt/web/RBACRestrictorTest.java
@@ -91,35 +91,37 @@ public class RBACRestrictorTest {
     private class MockJMXSecurity extends JMXSecurity {
         @Override
         public boolean canInvoke(String objectName, String methodName) throws Exception {
-            LOG.debug("{}, {}", objectName, methodName);
-            if ("hawtio:type=Test".equals(objectName) && "allowed".equals(methodName)) {
-                return true;
-            }
-            if ("hawtio:type=Test".equals(objectName) && "error".equals(methodName)) {
-                throw new Exception();
-            }
-            if ("hawtio:type=NoSuchType".equals(objectName) && "noInstance".equals(methodName)) {
-                throw new InstanceNotFoundException(objectName);
-            }
-            if ("java.lang:type=Runtime".equals(objectName) && "getVmName".equals(methodName)) {
-                return true;
-            }
-            if ("java.lang:type=Memory".equals(objectName) && "isVerbose".equals(methodName)) {
-                return true;
-            }
             return false;
         }
 
         @Override
         public boolean canInvoke(String objectName, String methodName, String[] argTypes) throws Exception {
             LOG.debug("{}, {}, {}", objectName, methodName, Arrays.asList(argTypes));
-            if ("hawtio:type=Test".equals(objectName) && "allowed".equals(methodName) && argTypes.length == 3
-                    && "boolean".equals(argTypes[0]) && "long".equals(argTypes[1]) && "java.lang.String".equals(argTypes[2])) {
-                return true;
-            }
-            if ("java.lang:type=Memory".equals(objectName) && "setVerbose".equals(methodName) && argTypes.length == 1
-                    && "boolean".equals(argTypes[0])) {
-                return true;
+            if (argTypes.length == 0) {
+                if ("hawtio:type=Test".equals(objectName) && "allowed".equals(methodName)) {
+                    return true;
+                }
+                if ("hawtio:type=Test".equals(objectName) && "error".equals(methodName)) {
+                    throw new Exception();
+                }
+                if ("hawtio:type=NoSuchType".equals(objectName) && "noInstance".equals(methodName)) {
+                    throw new InstanceNotFoundException(objectName);
+                }
+                if ("java.lang:type=Runtime".equals(objectName) && "getVmName".equals(methodName)) {
+                    return true;
+                }
+                if ("java.lang:type=Memory".equals(objectName) && "isVerbose".equals(methodName)) {
+                    return true;
+                }
+            } else {
+                if ("hawtio:type=Test".equals(objectName) && "allowed".equals(methodName) && argTypes.length == 3
+                        && "boolean".equals(argTypes[0]) && "long".equals(argTypes[1]) && "java.lang.String".equals(argTypes[2])) {
+                    return true;
+                }
+                if ("java.lang:type=Memory".equals(objectName) && "setVerbose".equals(methodName) && argTypes.length == 1
+                        && "boolean".equals(argTypes[0])) {
+                    return true;
+                }
             }
             return false;
         }


### PR DESCRIPTION
A small improvement to #2153.