### PR TITLE
Fix issue with blanks in URIs in log/source browser.

### DIFF
--- a/hawtio-web/src/main/webapp/app/source/js/source.ts
+++ b/hawtio-web/src/main/webapp/app/source/js/source.ts
@@ -43,7 +43,7 @@ module Source {
         path = fileName.substring(0, fileName.length - 5);
       }
       if (path) {
-        return "javadoc/" + mavenCoords + "/" + path + ".html";
+        return "javadoc/" + encodeURIComponent(mavenCoords) + "/" + path + ".html";
       }
       return null;
     };
@@ -97,7 +97,7 @@ module Source {
     function updateView() {
       var mbean = Source.getInsightMBean(workspace);
       if (mbean) {
-        jolokia.execute(mbean, "getSource", mavenCoords, className, fileName, {
+        jolokia.execute(mbean, "getSource", encodeURIComponent(mavenCoords), className, fileName, {
           success: viewContents,
           error: (response) => {
             log.error("Failed to download the source code for the Maven artifact: ", mavenCoords);


### PR DESCRIPTION
Fixes issues with blanks in paths when browsing sources with the maven plugin.

java.net.URISyntaxException: Illegal character in path at index 133: http://camel-standalone:8181/jolokia/exec/io.fabric8.insight:type=LogQuery/getSource/se.kth.infosys.camel:camel-spring:0.0.1-SNAPSHOT org.apache.camel:camel-core:2.17.3 com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4.2 org.slf4j:slf4j-api:1.7.21 com.sun.istack:istack-commons-runtime:2.21 org.glassfish.jaxb:jaxb-core:2.2.11 org.glassfish.jaxb:txw2:2.2.11 com.sun.xml.bind:jaxb-core:2.2.11 org.glassfish.jaxb:jaxb-runtime:2.2.11 com.sun.xml.bind:jaxb-impl:2.2.11 org.apache.camel:camel-spring:2.17.3 commons-logging:commons-logging:1.2 org.apache.activemq:activemq-camel:5.14.0 org.apache.camel:camel-jms:2.16.3 org.apache.activemq:activemq-spring:5.14.0 org.apache.xbean:xbean-spring:3.18 org.apache.activemq:activemq-broker:5.14.0 org.apache.activemq:activemq-client:5.14.0 org.apache.geronimo.specs:geronimo-jms_1.1_spec:1.1.1 org.fusesource.hawtbuf:hawtbuf:1.11 org.apache.geronimo.specs:geronimo-j2ee-management_1.1_spec:1.0.1 org.apache.activemq:activemq-openwire-legacy:5.14.0 org.apache.activemq:activemq-pool:5.14.0 org.apache.activemq:activemq-jms-pool:5.14.0 org.apache.geronimo.specs:geronimo-jta_1.0.1B_spec:1.0.1 org.apache.commons:commons-pool2:2.4.2 org.jolokia:jolokia-spring:1.3.4
...