### PR TITLE
Allow semicolons in user passwords when doing basic authentication

### DIFF
--- a/hawtio-system/src/main/java/io/hawt/system/Authenticator.java
+++ b/hawtio-system/src/main/java/io/hawt/system/Authenticator.java
@@ -55,12 +55,12 @@ public class Authenticator {
 
         if (authType.equalsIgnoreCase(AUTHENTICATION_SCHEME_BASIC)) {
             String decoded = new String(Base64.decodeBase64(authInfo));
-            parts = decoded.split(":");
-            if (parts.length != 2) {
+            int delimiter = decoded.indexOf(':');
+            if(delimiter<0){
                 return;
             }
-            String user = parts[0];
-            String password = parts[1];
+            String user = decoded.substring(0,delimiter);
+            String password = decoded.substring(delimiter+1);
             cb.getAuthInfo(user, password);
         }
     }


### PR DESCRIPTION
This solves https://github.com/hawtio/hawtio/issues/2195. This still doesn't allow semicolons in  usernames though but it's a start. Perhaps we should put the username and password in different headers?

Cheers!