### PR TITLE
Keycloak integration with hawtio on EAP

### DIFF
--- a/hawtio-web/src/main/webapp/app/core/js/keycloakLogin.ts
+++ b/hawtio-web/src/main/webapp/app/core/js/keycloakLogin.ts
@@ -64,6 +64,9 @@ module Core {
         var keycloakContext: KeycloakContext = createKeycloakContext(true);
         callback(keycloakContext);
       }
+      scriptEl.onerror = function() {
+        log.error("Not able to load keycloak.js from: " + scriptUrl);
+      }
 
       document.getElementsByTagName("body")[0].appendChild(scriptEl);
     }
@@ -155,14 +158,46 @@ module Core {
           log.debug('Keycloak authentication token found! Attach it to JQuery requests');
 
           $.ajaxSetup(<JQueryAjaxSettings> {
-            beforeSend: (xhr) => {
-              if (keycloak.authenticated) {
+
+            beforeSend: (xhr, settings) => {
+              if (keycloak.authenticated && !keycloak.isTokenExpired(10)) {
                 xhr.setRequestHeader('Authorization', Core.getBasicAuthHeader(keycloak.tokenParsed.preferred_username, keycloak.token));
+              } else {
+                log.debug("Skipped request " + settings.url + " for now.");
+                keycloak.updateToken(10).success(function(refreshed) {
+                  if (refreshed) {
+                    log.debug('Keycloak token refreshed. Set new value to userDetails');
+                  }
+
+                  log.debug("Re-sending request after successfully update keycloak token: " + settings.url);
+                  $.ajax(settings);
+                }).error(function() {
+                  log.warn('Failed to refresh keycloak token!');
+                  keycloak.logout();
+                });
+
+                return false;
               }
+            }
+
+          });
+
+          // Check if able to retrieve user's details
+          $.ajax("user", <JQueryAjaxSettings> {
+            type: "GET",
+            success: function (response) {
+              log.debug("Got response from user's details: ", response);
+              if (response && response != null) {
+                callback();
+              } else {
+                notification('error', 'Failed to log in or Unauthorized');
+              }
+            },
+            error: function (xhr, textStatus, error) {
+              notification('error', 'Failed to log in, ' + error);
             }
           });
 
-          callback();
         } else {
           notification('error', 'Keycloak auth token not found.');
         }
@@ -211,30 +246,6 @@ module Core {
           log.debug('keycloakAuth.onAuthLogout triggered!');
           Core.logout(jolokiaUrl, userDetails, localStorage, $rootScope);
         };
-
-        // Handle periodic refreshing of keycloak token. Token validity is checked each 5 seconds and token is refreshed if it is going to expire
-        // Periodic refreshment is stopped once we detect that we are not logged anymore to keycloak
-        var setPeriodicTokenRefresh = function() {
-          if (keycloakAuth.authenticated) {
-            setTimeout(function() {
-              keycloakAuth.updateToken(10).success(function(refreshed) {
-                if (refreshed) {
-                  log.debug('Keycloak token refreshed. Set new value to userDetails');
-                  userDetails.password = keycloakAuth.token;
-                }
-              }).error(function() {
-                log.warn('Failed to refresh keycloak token!');
-                Core.logout(jolokiaUrl, userDetails, localStorage, $rootScope);
-              });
-
-              // Setup timeout again, so it is checked again next 5 seconds
-              setPeriodicTokenRefresh();
-            }, 5000);
-          } else {
-            log.debug('Keycloak not authenticated any more. Skip period for token refreshing');
-          }
-        }
-        setPeriodicTokenRefresh();
 
       }
     };

--- a/sample-keycloak-integration/README.md
+++ b/sample-keycloak-integration/README.md
@@ -10,13 +10,13 @@ Prepare Keycloak server
 
 **1)** Download file [demorealm.json](demorealm.json) with Keycloak sample metadata about `hawtio-demo` realm. It's assumed you downloaded it to directory `/downloads` on your laptop. 
 
-**2)**  Download keycloak server from [http://www.keycloak.org](http://www.keycloak.org) and download version 2.2.0.Final . 
+**2)**  Download keycloak server from [http://www.keycloak.org](http://www.keycloak.org) and download version 2.2.1.Final . 
 Then unpack and run keycloak server on localhost:8081 . You also need to import downloaded `demorealm.json` file into your Keycloak. Import can be done either via Keycloak admin console or by 
 using `keycloak.import` system property:
 
 ```
-unzip -q /downloads/keycloak-2.2.0.Final.zip
-cd keycloak-2.2.0.Final/bin/
+unzip -q /downloads/keycloak-2.2.1.Final.zip
+cd keycloak-2.2.1.Final/bin/
 ./standalone.sh -Djboss.http.port=8081 -Dkeycloak.import=/downloads/demorealm.json
 ```
 
@@ -84,7 +84,7 @@ features:install hawtio
 * Install keycloak OSGI bundling into Fuse/Karaf . It contains few jars with Keycloak adapter and also configuration of `keycloak` JAAS realm
 
 ```
-features:addurl mvn:org.keycloak/keycloak-osgi-features/2.2.0.Final/xml/features
+features:addurl mvn:org.keycloak/keycloak-osgi-features/2.2.1.Final/xml/features
 features:install keycloak-jaas
 ```
 
@@ -188,6 +188,20 @@ Also add hawtio realm to this file to `security-domains` section:
     </authentication>
 </security-domain>
 ```
+
+* Install Keycloak adapter subsystem to your Wildfly as described in [Keycloak documentation](http://www.keycloak.org) .
+
+* Add the `secure-deployment` section hawtio into `$JBOSS_HOME/standalone/configuration/standalone.xml`  to the keycloak subsystem. 
+It should ensure that Hawtio WAR is able to find the JAAS login modules.
+ 
+```
+<subsystem xmlns="urn:jboss:domain:keycloak:1.1">
+    <secure-deployment name="hawtio.war">
+        <resource>does-not-matter</resource>
+        <auth-server-url>does-not-matter</auth-server-url>
+    </secure-deployment>
+</subsystem>
+```        
 
 * Run WildFly on port 8081 as described in [Prepare Keycloak Server](#prepare-keycloak-server) section and go to [http://localhost:8081/hawtio](http://localhost:8081/hawtio) . 
 Users are again `root` and `john` with access and `mary` without access. 


### PR DESCRIPTION
- Test and update instructions for Keycloak with hawtio on EAP 7
- Upgrade instructions to Keycloak 2.2.1, which has fix for nasty javascript bug
- Better error handling on refreshing token or when keycloak server not available