### PR TITLE
Fix #2224 Hawtio cannot run on WildFly when RBAC is enabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 
 ### Change Log
 
+#### 1.4.68
+
+* Fixed hawtio-wildfly to run on WildFly / JBoss EAP even after JBoss RBAC is enabled.
+
 #### 1.4.67
 
 * Fixed hawtio-app may not start due two different versions of http-client included.

--- a/hawtio-system/src/main/java/io/hawt/web/LoginServlet.java
+++ b/hawtio-system/src/main/java/io/hawt/web/LoginServlet.java
@@ -86,8 +86,14 @@ public class LoginServlet extends HttpServlet {
             return;
         }
 
-        AccessControlContext acc = AccessController.getContext();
-        Subject subject = Subject.getSubject(acc);
+        Subject subject = null;
+        if (System.getProperty("jboss.server.name") != null) {
+            // In WildFly / JBoss EAP privileged action is skipped at AuthenticationFilter
+            subject = (Subject) req.getAttribute("subject");
+        } else {
+            AccessControlContext acc = AccessController.getContext();
+            subject = Subject.getSubject(acc);
+        }
 
         if (subject == null) {
             Helpers.doForbidden(resp);


### PR DESCRIPTION
Turned out `Subject.doAs(...)` is effectively not available on WildFly / JBoss EAP, so we need to go direct in-vm call when Hawtio detects it's running on WildFly / JBoss EAP.