### PR TITLE
Updated commons-fileupload to version 1.3.2 to remove DoS vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <build-helper-maven-plugin-version>1.7</build-helper-maven-plugin-version>
     <camel-version>2.18.0</camel-version>
     <commons-codec-version>1.10</commons-codec-version>
-    <commons-fileupload-version>1.3.1</commons-fileupload-version>
+    <commons-fileupload-version>1.3.2</commons-fileupload-version>
     <httpclient-version>4.5.2</httpclient-version>
     <commons-io-version>2.2</commons-io-version>
     <commons-logging-version>1.1.3</commons-logging-version>


### PR DESCRIPTION
Updating the version of Apache Commons FileUpload from 1.3.1 to 1.3.2 to remediate a vulnerability as per https://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2014-0050
