### PR TITLE
Fix #2233 Most of the actions on the app were flickering

### DIFF
--- a/hawtio-web/src/main/webapp/app/camel/js/camelPlugin.ts
+++ b/hawtio-web/src/main/webapp/app/camel/js/camelPlugin.ts
@@ -67,7 +67,7 @@ module Camel {
       return workspace.treeContainsDomainAndProperties(camelJmxDomain);
     });
     preferencesRegistry.addTab('Camel', 'app/camel/html/preferences.html', () => {
-      return workspace.treeContainsDomainAndProperties(camelJmxDomain); 
+      return workspace.treeContainsDomainAndProperties(camelJmxDomain);
     });
 
     // TODO should really do this via a service that the JMX plugin exposes

--- a/hawtio-web/src/main/webapp/app/jmx/js/attributes.ts
+++ b/hawtio-web/src/main/webapp/app/jmx/js/attributes.ts
@@ -35,7 +35,7 @@ module Jmx {
                                        jmxWidgetTypes,
                                        $templateCache,
                                        localStorage,
-                                        $browser) => {
+                                       $browser) => {
     $scope.searchText = '';
     $scope.nid = 'empty';
     $scope.selectedItems = [];
@@ -130,7 +130,7 @@ module Jmx {
       $scope.nid = $location.search()['nid'];
       log.debug("nid: ", $scope.nid);
 
-      setTimeout(updateTableContents, 50);
+      pendingUpdate = setTimeout(updateTableContents, 50);
     });
 
     $scope.$on('jmxTreeUpdated', function () {
@@ -138,9 +138,7 @@ module Jmx {
       if (pendingUpdate) {
         clearTimeout(pendingUpdate);
       }
-      pendingUpdate = setTimeout(() => {
-        updateTableContents();
-      }, 500);
+      pendingUpdate = setTimeout(updateTableContents, 500);
     });
 
     var pendingUpdate = null;
@@ -150,9 +148,7 @@ module Jmx {
       if (pendingUpdate) {
         clearTimeout(pendingUpdate);
       }
-      pendingUpdate = setTimeout(() => {
-        updateTableContents();
-      }, 500);
+      pendingUpdate = setTimeout(updateTableContents, 500);
     });
 
     $scope.$watch('workspace.selection', function () {
@@ -160,12 +156,13 @@ module Jmx {
         Core.unregister(jolokia, $scope);
         return;
       }
-      setTimeout(() => {
+      if (pendingUpdate) {
+        clearTimeout(pendingUpdate);
+      }
+      pendingUpdate = setTimeout(() => {
         $scope.gridData = [];
         Core.$apply($scope);
-        setTimeout(() => {
-          updateTableContents();
-        }, 10);
+        setTimeout(updateTableContents, 10);
       }, 10);
     });
 


### PR DESCRIPTION
This fixes https://github.com/hawtio/hawtio/issues/2233

![no-flicker](https://cloud.githubusercontent.com/assets/8288413/20915855/0ed77222-bb91-11e6-877f-e22414c43741.gif)

The problem was found inside the Jmx.AttributesController because:
1) `$on("$routeChangeSuccess)" was triggering an `updateTableContents` with a timeout
2) other `$watch`es in the controller were also triggering `updateTableContents`. but these watches were cleaning up the timeout if it was previously setting
3) the fix was to wire the `updateTableContents` on route change success to the cleanup as well

Most of the navigation actions had this problem. While the initial ticket #2233 only mentioned Camel, this fix covers all the flicker problems where JMX attributes module was used