### PR TITLE
Problem with simpleDataTable.isSelected

### DIFF
--- a/hawtio-web/src/main/webapp/app/datatable/js/simpleDataTable.ts
+++ b/hawtio-web/src/main/webapp/app/datatable/js/simpleDataTable.ts
@@ -236,7 +236,11 @@ module DataTable {
       };
 
       $scope.isSelected = (row) => {
-        return (row) && config.selectedItems.some(row.entity);
+        return (row) && config.selectedItems.some(s => {
+              var spk = primaryKeyFn(s, s.index);
+              var rpk = primaryKeyFn(row.entity, row.index);
+              return angular.equals(spk, rpk);
+            });
       };
 
       $scope.onRowClicked = (row) => {


### PR DESCRIPTION
I'm working on a plugin that uses simpleDataTable. It gives javascript errors as row.entity is attempted passed as a function to array.some(...). 

By using similar logic as in reSelectedItems the problem appears to be fixed. Have run both Camel and Quartz plugins without experiencing issues. 

The use of 's.index' appears a bit suspect, but works in my case as the primaryKeyFn only relies on the entity. 
