### PR TITLE
Issue2339

### DIFF
--- a/hawtio-web/src/main/webapp/app/jvm/js/discover.ts
+++ b/hawtio-web/src/main/webapp/app/jvm/js/discover.ts
@@ -26,7 +26,7 @@ module JVM {
         return;
       }
       var options:Core.ConnectToServerOptions = Core.createConnectOptions();
-      options.name = agent.agent_description;
+      options.name = agent.agent_description  || 'discover-' + agent.agent_id;
       var urlObject = Core.parseUrl(agent.url);
       angular.extend(options, urlObject);
       options.userName = agent.username;


### PR DESCRIPTION
Resolves issue #2339 .

Discovered connections will now appear as, eg.
![image](https://user-images.githubusercontent.com/6298906/27572589-1d87e678-5b0d-11e7-98a9-1476c32ced2f.png)
Which I guess is useful as it includes host and port. 