### PR TITLE
Quartz manual trigger dialog

### DIFF
--- a/hawtio-web/src/main/webapp/app/quartz/doc/help.md
+++ b/hawtio-web/src/main/webapp/app/quartz/doc/help.md
@@ -2,8 +2,8 @@
 
 The [Quartz](#/quartz/schedulers/) plugin in [hawtio](http://hawt.io "hawtio") offers functionality for viewing and managing Quartz Schedulers.
 
-#### Schedulers
-Here you can see the list of schedulers and their state. You can also pause and resume a scheduler.
+#### Scheduler
+Here you can see the scheduler its state and statistics. You can also pause and resume a scheduler.
 
 #### Jobs
 Jobs lists and allows you to see information about job definitions.

--- a/hawtio-web/src/main/webapp/app/quartz/doc/help.md
+++ b/hawtio-web/src/main/webapp/app/quartz/doc/help.md
@@ -2,3 +2,13 @@
 
 The [Quartz](#/quartz/schedulers/) plugin in [hawtio](http://hawt.io "hawtio") offers functionality for viewing and managing Quartz Schedulers.
 
+#### Schedulers
+Here you can see the list of schedulers and their state. You can also pause and resume a scheduler.
+
+#### Jobs
+Jobs lists and allows you to see information about job definitions.
+
+#### Triggers
+Here you see the existing triggers in the selected scheduler and their state, including previous and next fire times. Individual triggers can be paused and resumed. 
+You can also edit some properties of a scheduler or make it fire instantly regardless of the scheduler.
+ 

--- a/hawtio-web/src/main/webapp/app/quartz/html/triggers.html
+++ b/hawtio-web/src/main/webapp/app/quartz/html/triggers.html
@@ -48,7 +48,7 @@
       </div>
 
       <div hawtio-confirm-dialog="showManualTriggerDialog" ok-button-text="Trigger now" cancel-button-text="Cancel" on-ok="onManualTrigger()"
-           title="Manually invoke trigger: {{gridOptions.selectedItems[0].group}}/{{gridOptions.selectedItems[0].name}}">
+           title="Manually invoke trigger">
         <div class="dialog-body">
           <div simple-form data='manualTriggerSchema' entity='manualTrigger'>
           </div>

--- a/hawtio-web/src/main/webapp/app/quartz/html/triggers.html
+++ b/hawtio-web/src/main/webapp/app/quartz/html/triggers.html
@@ -19,7 +19,7 @@
               <div class="btn-group">
                 <button
                     ng-disabled="gridOptions.selectedItems.length == 0 || gridOptions.selectedItems[0].state != 'PAUSED'"
-                    class="btn" ng-click="resumeTrigger()" title="Resume trigger">
+                    class="btn" ng-click="resumeTrigger()" title="Resume triggerererer">
                   <i class="icon-play-circle"></i></button>
                 <button
                     ng-disabled="gridOptions.selectedItems.length == 0 || gridOptions.selectedItems[0].state == 'PAUSED'"
@@ -29,6 +29,10 @@
                     ng-disabled="gridOptions.selectedItems.length == 0"
                     class="btn" ng-click="onBeforeUpdateTrigger()" title="Update trigger">
                   <i class="icon-edit"></i></button>
+                <button
+                    ng-disabled="gridOptions.selectedItems.length == 0"
+                    class="btn" ng-click="onBeforeManualTrigger()" title="Manually trigger">
+                  <i class="icon-play"></i></button>
               </div>
             </div>
           </fieldset>
@@ -39,6 +43,14 @@
            title="Update trigger: {{gridOptions.selectedItems[0].group}}/{{gridOptions.selectedItems[0].name}}">
         <div class="dialog-body">
           <div simple-form data='triggerSchema' entity='updatedTrigger'>
+          </div>
+        </div>
+      </div>
+
+      <div hawtio-confirm-dialog="showManualTriggerDialog" ok-button-text="Trigger now" cancel-button-text="Cancel" on-ok="onManualTrigger()"
+           title="Manually invoke trigger: {{gridOptions.selectedItems[0].group}}/{{gridOptions.selectedItems[0].name}}">
+        <div class="dialog-body">
+          <div simple-form data='manualTriggerSchema' entity='manualTrigger'>
           </div>
         </div>
       </div>

--- a/hawtio-web/src/main/webapp/app/quartz/html/triggers.html
+++ b/hawtio-web/src/main/webapp/app/quartz/html/triggers.html
@@ -47,8 +47,8 @@
         </div>
       </div>
 
-      <div hawtio-confirm-dialog="showManualTriggerDialog" ok-button-text="Trigger now" cancel-button-text="Cancel" on-ok="onManualTrigger()"
-           title="Manually invoke trigger">
+      <div hawtio-confirm-dialog="showManualTriggerDialog" ok-button-text="Fire now" cancel-button-text="Cancel" on-ok="onManualTrigger()"
+           title="Manually fire trigger">
         <div class="dialog-body">
           <div simple-form data='manualTriggerSchema' entity='manualTrigger'>
           </div>

--- a/hawtio-web/src/main/webapp/app/quartz/html/triggers.html
+++ b/hawtio-web/src/main/webapp/app/quartz/html/triggers.html
@@ -19,7 +19,7 @@
               <div class="btn-group">
                 <button
                     ng-disabled="gridOptions.selectedItems.length == 0 || gridOptions.selectedItems[0].state != 'PAUSED'"
-                    class="btn" ng-click="resumeTrigger()" title="Resume triggerererer">
+                    class="btn" ng-click="resumeTrigger()" title="Resume trigger">
                   <i class="icon-play-circle"></i></button>
                 <button
                     ng-disabled="gridOptions.selectedItems.length == 0 || gridOptions.selectedItems[0].state == 'PAUSED'"

--- a/hawtio-web/src/main/webapp/app/quartz/js/quartz.ts
+++ b/hawtio-web/src/main/webapp/app/quartz/js/quartz.ts
@@ -27,6 +27,7 @@ module Quartz {
       {id: '2', title: 'Do nothing'}
     ];
     $scope.updatedTrigger = {};
+    $scope.manualTrigger = {};
     $scope.triggerSchema = {
       properties: {
         'cron': {
@@ -61,6 +62,21 @@ module Quartz {
       }
     };
 
+    $scope.manualTriggerSchema = {
+      properties: {
+        'name': {
+          type: 'string'
+        },
+        'group': {
+          type: 'string',
+        },
+        'parameters': {
+          tooltip: 'Parameters if any (java.util.Map in JSON syntax)',
+          type: 'string'
+        }
+      }
+    };
+    
     $scope.gridOptions = {
       selectedItems: [],
       data: 'triggers',
@@ -302,6 +318,7 @@ module Quartz {
         data.detailHtml = detailHtml;
       }
     }
+    
 
     $scope.pauseScheduler = () => {
       if ($scope.selectedSchedulerMBean) {
@@ -394,6 +411,20 @@ module Quartz {
         $scope.showTriggerDialog = false;
       }
     }
+    
+    $scope.onBeforeManualTrigger = () => {
+      var row = $scope.gridOptions.selectedItems[0];
+      if (row) {
+        $scope.manualTrigger["name"] = row.jobName;
+        $scope.manualTrigger["group"] = row.jobGroup;
+        $scope.manualTrigger["parameters"] = '{}';
+        $scope.showManualTriggerDialog = true;
+      } else {
+        $scope.manualTrigger = {};
+        $scope.showManualTriggerDialog = false;
+      }
+    }
+    
 
     $scope.onUpdateTrigger = () => {
       var cron = $scope.updatedTrigger["cron"];
@@ -445,6 +476,30 @@ module Quartz {
           ));
       }
     }
+    function onManualTriggerError(response) {
+      Core.notification("error", "Could not manually trigger " + response.request.arguments[1] + "/" + response.request.arguments[0] + " due to: " + response.error);
+    }
+    
+    function onManualTriggerSuccess(response) {
+      Core.notification("success", "Manually triggered " + response.request.arguments[1] + "/" + response.request.arguments[0]);
+    }
+    
+    $scope.onManualTrigger = () => {
+      var parameters = JSON.parse($scope.manualTrigger["parameters"]);
+      var groupName = $scope.manualTrigger["group"];
+      var triggerName = $scope.manualTrigger["name"];
+
+      $scope.manualTrigger = {};
+      log.info("Mannually triggering " + groupName + "/" + triggerName + " with parameters " + parameters);
+
+      jolokia.request({type: "exec", mbean: $scope.selectedSchedulerMBean,
+          operation: "triggerJob", arguments: [
+            triggerName,
+            groupName,
+            parameters]},
+          onSuccess(onManualTriggerSuccess, {error: onManualTriggerError}) );      
+    }
+    
 
     function reloadTree() {
       log.debug("Reloading Quartz Tree")

--- a/hawtio-web/src/main/webapp/app/quartz/js/quartz.ts
+++ b/hawtio-web/src/main/webapp/app/quartz/js/quartz.ts
@@ -477,11 +477,11 @@ module Quartz {
       }
     }
     function onManualTriggerError(response) {
-      Core.notification("error", "Could not manually trigger " + response.request.arguments[1] + "/" + response.request.arguments[0] + " due to: " + response.error);
+      Core.notification("error", "Could not manually fire trigger " + response.request.arguments[1] + "/" + response.request.arguments[0] + " due to: " + response.error);
     }
     
     function onManualTriggerSuccess(response) {
-      Core.notification("success", "Manually triggered " + response.request.arguments[1] + "/" + response.request.arguments[0]);
+      Core.notification("success", "Manually fired trigger " + response.request.arguments[1] + "/" + response.request.arguments[0]);
     }
     
     $scope.onManualTrigger = () => {
@@ -490,7 +490,7 @@ module Quartz {
       var triggerName = $scope.manualTrigger["name"];
 
       $scope.manualTrigger = {};
-      log.info("Mannually triggering " + groupName + "/" + triggerName + " with parameters " + parameters);
+      log.info("Mannually firing trigger " + groupName + "/" + triggerName + " with parameters " + parameters);
 
       jolokia.request({type: "exec", mbean: $scope.selectedSchedulerMBean,
           operation: "triggerJob", arguments: [


### PR DESCRIPTION
Allows the developer to invoke a Quartz trigger directly from the GUI in order to test the underlying application.

Usage: 
Select a trigger in the Quartz/triggers tab.
Hit the play button to the trigger toolbar.
![image](https://user-images.githubusercontent.com/6298906/27761161-24b3ffde-5e57-11e7-9b8a-3be1e0a6bf5b.png)

A dialog with parameters will appear:
![image](https://user-images.githubusercontent.com/6298906/27761165-3c69096c-5e57-11e7-9c00-0558b94289ba.png)

Hit "Trigger now" and a message with the outcome will appear. 
Inn addition the last previous fire timestamp in the table will be updated:
Manual trigger is possible even if the trigger is paused.

![image](https://user-images.githubusercontent.com/6298906/27761178-74c2386a-5e57-11e7-801a-c75aed95a317.png)

This new feature is unfortunately affected by the same bug as the edit dialog, described in issue #2348. 


