### PR TITLE
#2350 detect what parts of the diagnostic tools are in fact available

### DIFF
--- a/hawtio-web/src/main/webapp/app/diagnostics/js/diagnosticHelpers.ts
+++ b/hawtio-web/src/main/webapp/app/diagnostics/js/diagnosticHelpers.ts
@@ -37,13 +37,13 @@ module Diagnostics {
       {
         content: '<i class="icon-plane"></i> Flight Recorder',
         title: "Make flight recordings",
-        isValid: (workspace:Workspace) => true,
+        isValid: (workspace:Workspace) => hasDiagnosticFunction(workspace, 'jfrCheck'),
         href: "#/diagnostics/jfr"
       },
       {
         content: '<i class="icon-hdd"></i> Heap Use',
         title: "See heap use",
-        isValid: (workspace:Workspace) => true,
+        isValid: (workspace:Workspace) => hasDiagnosticFunction(workspace, 'gcClassHistogram'),
         href: "#/diagnostics/heap"
       },
       {
@@ -59,6 +59,24 @@ module Diagnostics {
 
   export function hasHotspotDiagnostic(workspace) {
     return workspace.treeContainsDomainAndProperties('com.sun.management', {type: 'HotSpotDiagnostic'});
+  }
+    
+  export function hasDiagnosticFunction(workspace:Workspace, operation:string) {
+       var diagnostics:Folder=workspace.findMBeanWithProperties('com.sun.management', {type: 'DiagnosticCommand'});
+       return diagnostics && diagnostics.mbean && diagnostics.mbean.op && diagnostics.mbean.op[operation];
+  }
+    
+  export function initialTab(workspace:Workspace) : string {
+      if(hasDiagnosticFunction(workspace, 'jfrCheck')) {
+          return '/jfr';
+      } else if(hasDiagnosticFunction(workspace, 'gcClassHistogram')) {
+          return '/heap';
+      } else if(hasHotspotDiagnostic(workspace)) {
+          return '/flags';
+      } else {
+          return '';
+      }
+      
   }
   
   export function findMyPid(title) {

--- a/hawtio-web/src/main/webapp/app/diagnostics/js/diagnosticsPlugin.ts
+++ b/hawtio-web/src/main/webapp/app/diagnostics/js/diagnosticsPlugin.ts
@@ -34,10 +34,10 @@ module Diagnostics {
       content: "Diagnostics",
       title: "JVM Diagnostics",
       isValid: (workspace) => {
-          return workspace.treeContainsDomainAndProperties("com.sun.management")
+          return workspace.treeContainsDomainAndProperties("com.sun.management") && initialTab(workspace);
       },
       href: () => {
-        return '#/diagnostics/jfr';
+        return '#/diagnostics' + initialTab(workspace);
       },
       isActive: (workspace:Workspace) => workspace.isLinkActive("diagnostics")
     });


### PR DESCRIPTION
Tested on zulu JDK where Heap tab is shown and selected , and flight recorder tab is hidden. 

All three tabs still appear in Oracle JDK8.

Since the tab breadcrumbs are built in diagnosticsHelpers.ts one alternative would be to only add the breadcrumbs that are valid and pick the URL of the first breadcrumb if any, instead of adding all with isValid filters. 

