### PR TITLE
Detect more details about the JVM of the discovered agents

### DIFF
--- a/hawtio-web/src/main/webapp/app/jvm/html/discover.html
+++ b/hawtio-web/src/main/webapp/app/jvm/html/discover.html
@@ -70,8 +70,11 @@
             <span ng-class="getAgentIdClass(agent)">
               <strong ng-show="hasName(agent)">Agent ID: </strong>{{agent.agent_id}}<br/>
               <strong ng-show="hasName(agent)">Agent Version: </strong><span ng-hide="hasName(agent)"> Version: </span>{{agent.agent_version}}</span><br/>
-              <strong ng-show="hasName(agent)">Agent Description: </strong><span
-                ng-hide="hasName(agent)"> Description: </span>{{agent.agent_description}}</span><br/>
+              <strong ng-show="hasName(agent)&&!!agent.agent_description">Agent Description: </strong>
+              <div
+                ng-hide="hasName(agent)||!agent.agent_description"><strong>Description: </strong>{{agent.agent_description}}</div>
+              <div ng-hide="!agent.startTime"><strong>JVM Started: </strong>{{agent.startTime | date: 'yyyy-MM-dd HH:mm:ss'}}</div>
+              <div ng-hide="!agent.command"><strong>Java Command: </strong>{{agent.command}}</div>
 
               <p ng-hide="!agent.url"><strong>Agent URL: </strong><a ng-href="{{agent.url}}"
                                                                      target="_blank">{{agent.url}}</a>

--- a/hawtio-web/src/main/webapp/app/jvm/js/discover.ts
+++ b/hawtio-web/src/main/webapp/app/jvm/js/discover.ts
@@ -2,6 +2,7 @@
  * @module JVM
  */
 /// <reference path="../../core/js/coreInterfaces.ts"/>
+/// <reference path="../../core/js/coreHelpers.ts"/>
 /// <reference path="jvmPlugin.ts"/>
 module JVM {
 
@@ -19,6 +20,19 @@ module JVM {
     $scope.closePopover = ($event) => {
       (<JQueryStatic>$)($event.currentTarget).parents('.popover').prev().popover('hide');
     };
+      
+    function getMoreJvmDetails(agents){
+        for(var key in agents) {
+            var agent=agents[key];
+            if(agent.url && !agent.secured ) {
+                var dedicatedJolokia=Core.createJolokia(agent.url, agent.username, agent.password);
+                agent.startTime=dedicatedJolokia.getAttribute('java.lang:type=Runtime', 'StartTime');
+                if(!$scope.hasName(agent)){//only look for command if agent vm is not known
+                    agent.command=dedicatedJolokia.getAttribute('java.lang:type=Runtime', 'SystemProperties', 'sun.java.command');
+                }
+            }
+        }
+    }
 
     function doConnect(agent) {
       if (!agent.url) {
@@ -87,6 +101,7 @@ module JVM {
         if ($scope.responseJson !== responseJson) {
           $scope.responseJson = responseJson;
           $scope.agents = response;
+          getMoreJvmDetails($scope.agents);
         }
       }
       Core.$apply($scope);


### PR DESCRIPTION
Idea: provide more details about the Java application of the discovered agents. This can be useful if there are a lot of different Java processes running and one wants an idea of which is which before actually connecting. It will only be attempted for connections without authentication (did not find a good way to deal with authentication). A downside is that there may be up to a couple of extra requests for each discovered agent. However the timeout for the discovery process is so long that the user will probably not notice much difference.

On a best effort basis, the following is attempted for each generic detected vm: 
- Main class / jar file and arguments
- Start time of the application (you often have an idea about when a version was deployed)

![image](https://user-images.githubusercontent.com/6298906/27996801-85c5040a-64ea-11e7-9687-d0986bbe755d.png)
