### PR TITLE
JFR support for Java 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ hawtio-config
 node/
 bower_components/
 .vscode
+*.jfr

--- a/hawtio-web/src/main/webapp/app/diagnostics/html/jfr.html
+++ b/hawtio-web/src/main/webapp/app/diagnostics/html/jfr.html
@@ -74,10 +74,10 @@
 						<i class="icon-5x"
 							ng-class="jfrEnabled ? 'icon-unlock' : 'icon-lock'"></i>
 					</button>
-					<button class="recorderButton btn" ng-enabled="!isRecording"
-						ng-class="!jfrEnabled || isRecording ? 'disabled' : 'raisedButton'"
+					<button class="recorderButton btn" ng-enabled="!isRunning"
+						ng-class="!jfrEnabled || isRunning ? 'disabled' : 'raisedButton'"
 						tooltip="Start recording"
-						ng-click="startRecording()" ng-disabled="isRecording">
+						ng-click="startRecording()" ng-disabled="isRunning" >
 						<div class="recordingSymbol" id="rec"></div>
 					</button>
 					<button class="recorderButton btn" title="Dump recording to disk"

--- a/hawtio-web/src/main/webapp/app/diagnostics/js/jfr.ts
+++ b/hawtio-web/src/main/webapp/app/diagnostics/js/jfr.ts
@@ -6,7 +6,6 @@
 module Diagnostics {
 
     function splitResponse( response:string ) {
-        //Dumped recording "Recording 8", 7,1 MB written to: /Users/marska/Documents/dev/hawtio/hawtio-web/recording8.jfr
         return response.match( /Dumped recording "(.+)",(.+) written to:\r?\n\r?\n(.+)/ );
     }
 

--- a/hawtio-web/src/main/webapp/app/diagnostics/js/jfr.ts
+++ b/hawtio-web/src/main/webapp/app/diagnostics/js/jfr.ts
@@ -89,7 +89,11 @@ module Diagnostics {
             }
             $scope.jfrStatus = statusString;
             if ( $scope.isRecording ) {
-                var regex = /recording=(\d+) name="(.+?)"/g;
+                    var regex = /recording=(\d+) name="(.+?)"/g;
+                if($scope.isRunning) { //if there are several recordings (some stopped), make sure we parse the running one
+                    regex = /recording=(\d+) name="(.+?)".+?\(running\)/g;
+                }
+                
                 var parsed=regex.exec( statusString );
                 $scope.jfrSettings.recordingNumber = parsed[1];
                 $scope.jfrSettings.name = parsed[2];
@@ -218,6 +222,10 @@ module Diagnostics {
         };
 
         $scope.startRecording = () => {
+            if($scope.isRecording) {//this means that there is a stopped recording, clear state before starting the next
+                $scope.jfrSettings.name = null;
+                $scope.jfrSettings.filename = null;
+            }
             executeDiagnosticFunction( 'jfrStart([Ljava.lang.String;)', 'JFR.start', [buildStartParams( $scope.jfrSettings )], null );
         };
 

--- a/hawtio-web/src/main/webapp/app/diagnostics/js/jfr.ts
+++ b/hawtio-web/src/main/webapp/app/diagnostics/js/jfr.ts
@@ -18,8 +18,7 @@ module Diagnostics {
             params.push( 'filename="' + jfrSettings.filename + '"');
         }
         params.push( 'dumponexit=' + jfrSettings.dumpOnExit );
-        params.push( 'compress=' + jfrSettings.compress );
-        if ( jfrSettings.limitType != 'unlimited' ) {
+         if ( jfrSettings.limitType != 'unlimited' ) {
             params.push( jfrSettings.limitType + '=' + jfrSettings.limitValue );
         }
 
@@ -29,8 +28,7 @@ module Diagnostics {
     function buildDumpParams( jfrSettings: JfrSettings ) {
         return [
             'filename="' + jfrSettings.filename + '"',
-            'compress=' + jfrSettings.compress,
-            'recording=' + jfrSettings.recordingNumber
+            'name="' + jfrSettings.name + '"'
         ];
     }
 
@@ -42,7 +40,6 @@ module Diagnostics {
         limitType: string;
         limitValue: string;
         recordingNumber: string;
-        compress: boolean;
         dumpOnExit: boolean;
         name: string;
         filename: string;
@@ -189,19 +186,15 @@ module Diagnostics {
                 limitType: <Forms.FormElement>{
                     type: "java.lang.String",
                     tooltip: "Duration if any",
-                    enum: ['unlimited', 'duration']
+                    enum: ['unlimited', 'duration', 'maxsize']
                 },
                 limitValue: <Forms.FormElement>{
                     type: "java.lang.String",
-                    tooltip: "Limit value. duration: [val]s/m/h",
+                    tooltip: "Limit value. duration: [val]s/m/h, maxsize: [val]kB/MB/GB",
                     required: false,
                     "input-attributes": {
                         "ng-show": "jfrSettings.limitType != 'unlimited'"
                     }
-                },
-                compress: <Forms.FormElement>{
-                    type: "java.lang.Boolean",
-                    tooltip: "Compress recording"
                 },
                 dumpOnExit: <Forms.FormElement>{
                     type: "java.lang.Boolean",
@@ -252,10 +245,11 @@ module Diagnostics {
         }
 
         $scope.stopRecording = () => {
+            var name = $scope.jfrSettings.name;
             $scope.jfrSettings.filename = '';
             $scope.jfrSettings.name = '';
             executeDiagnosticFunction( 'jfrStop([Ljava.lang.String;)', 'JFR.stop',
-                ["recording=" + $scope.jfrSettings.recordingNumber], null );
+                ['name="' + name + '"'], null );
         }
         
         $scope.toggleSettingsVisible = () => {

--- a/hawtio-web/src/main/webapp/app/diagnostics/js/jfr.ts
+++ b/hawtio-web/src/main/webapp/app/diagnostics/js/jfr.ts
@@ -6,7 +6,8 @@
 module Diagnostics {
 
     function splitResponse( response:string ) {
-        return response.match( /Dumped recording (\d+),(.+) written to:\r?\n\r?\n(.+)/ );
+        //Dumped recording "Recording 8", 7,1 MB written to: /Users/marska/Documents/dev/hawtio/hawtio-web/recording8.jfr
+        return response.match( /Dumped recording "(.+)",(.+) written to:\r?\n\r?\n(.+)/ );
     }
 
     function buildStartParams( jfrSettings: JfrSettings ) {
@@ -144,7 +145,7 @@ module Diagnostics {
                 arguments: ['']
             }], onSuccess( function( response ) {
 
-                Diagnostics.log.debug( Date.now() + " Operation "
+                Diagnostics.log.debug("Diagnostic Operation "
                     + operation + " was successful" + response.value );
                 if ( response.request.operation.indexOf( "jfrCheck" ) > -1 ) {
                     render( response );
@@ -154,7 +155,10 @@ module Diagnostics {
                     }
                     Core.$apply( $scope );
                 }
-            }) );
+            }, {error: function(response){
+                        Diagnostics.log.warn("Diagnostic Operation "
+                    + operation + " failed" , response );
+                        }} ));
         }
 
 


### PR DESCRIPTION
Background: The DiagnosticCommand operations have both differing input requirements and response between Java 8 and Java 9.
Goal: Adjust the implementation so that it supports both versions.
Implementation details: 

- Drop compress option as it is no longer supported
- Base operations for existing recording on recording name rather than number
- Allow starting new recordings even if there are stopped ones (are not removed by stop in Java 9)
- Support maxsize limit of recordings

Tested successfully in Java versions 9+181, 1.8.102 & 1.8.152.
