### PR TITLE
Spring: add ability to disable Hawtio via properties

### DIFF
--- a/hawtio-springboot/pom.xml
+++ b/hawtio-springboot/pom.xml
@@ -35,6 +35,32 @@
       <artifactId>spring-boot-starter-web</artifactId>
       <version>${spring-boot-version}</version>
     </dependency>
+
+    <!-- testing -->
+    <dependency>
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit</artifactId>
+      <version>${jgit-version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit-version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.9.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>${spring-version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hawtio-springboot/src/main/java/io/hawt/springboot/HawtioConfiguration.java
+++ b/hawtio-springboot/src/main/java/io/hawt/springboot/HawtioConfiguration.java
@@ -22,6 +22,7 @@ import org.apache.commons.fileupload.servlet.FileCleanerCleanup;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.ManagementContextConfiguration;
 import org.springframework.boot.actuate.autoconfigure.ManagementServerProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
@@ -33,6 +34,7 @@ import org.springframework.context.annotation.PropertySource;
  * Management configuration for hawtio on Spring Boot
  */
 @ManagementContextConfiguration
+@ConditionalOnProperty(name = "hawtio.enabled", matchIfMissing = true)
 @EnableConfigurationProperties(HawtioProperties.class)
 @PropertySource("classpath:/io/hawt/springboot/application.properties")
 public class HawtioConfiguration {

--- a/hawtio-springboot/src/test/java/io/hawt/springboot/HawtioConfigurationTest.java
+++ b/hawtio-springboot/src/test/java/io/hawt/springboot/HawtioConfigurationTest.java
@@ -1,0 +1,51 @@
+package io.hawt.springboot;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.ManagementServerProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(Enclosed.class)
+@ContextConfiguration(classes = { HawtioConfiguration.class, HawtioConfigurationTest.TestConfiguration.class })
+public abstract class HawtioConfigurationTest {
+
+    @Autowired
+    protected ApplicationContext ctx;
+
+    @RunWith(SpringRunner.class)
+    public static class HawtioEnabledByDefaultTest extends HawtioConfigurationTest {
+
+        @Test
+        public void test() {
+            ctx.getBean(HawtioConfiguration.class);
+        }
+    }
+
+    @RunWith(SpringRunner.class)
+    @TestPropertySource(properties = "hawtio.enabled=false")
+    public static class HawtioCanBeDisabledTest extends HawtioConfigurationTest {
+
+        @Test(expected = NoSuchBeanDefinitionException.class)
+        public void test() {
+            ctx.getBean(HawtioConfiguration.class);
+        }
+    }
+
+    @Configuration
+    public static class TestConfiguration {
+
+        @Bean
+        public ManagementServerProperties serverProperties() {
+            return Mockito.mock(ManagementServerProperties.class);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <jgit-version>4.10.0.201712302008-r</jgit-version>
     <jline.version>3.2.0</jline.version>
     <jolokia-version>1.5.0</jolokia-version>
-    <junit-version>4.11</junit-version>
+    <junit-version>4.12</junit-version>
     <karaf-version>4.1.2</karaf-version>
     <karaf-version-range>[3.0,5)</karaf-version-range>
     <log4j-version>1.2.17</log4j-version>
@@ -326,6 +326,12 @@
             <basedir>${basedir}</basedir>
             <java.awt.headless>true</java.awt.headless>
           </systemPropertyVariables>
+
+          <!-- Empty exclude is required for nested test classes to run -->
+          <excludes>
+            <exclude></exclude>
+          </excludes>
+
           <includes>
             <include>**/*Test.*</include>
           </includes>


### PR DESCRIPTION
Sometimes it might not be desirable to start Hawtio automatically as soon as it is included on the class path. This enhancement allows to disable Hawtio via configuration property "hawtio.enabled" which defaults to "true", but can be overridden if necessary.