### PR TITLE
Use relative paths for icon images

### DIFF
--- a/hawtio-web/src/main/webapp/app/activemq/js/activemqPlugin.ts
+++ b/hawtio-web/src/main/webapp/app/activemq/js/activemqPlugin.ts
@@ -256,7 +256,7 @@ module ActiveMQ {
           var connectorName = entries["connectorName"];
           if (connectorName && !node.icon) {
             // lets default a connector icon
-            node.icon = Core.url("/img/icons/activemq/connector.png");
+            node.icon = Core.url("img/icons/activemq/connector.png");
           }
         }
         angular.forEach(node.children, (child) => setConsumerType(child));

--- a/hawtio-web/src/main/webapp/app/camel/js/camelHelpers.ts
+++ b/hawtio-web/src/main/webapp/app/camel/js/camelHelpers.ts
@@ -226,7 +226,7 @@ module Camel {
     }
     if (nodeSettings) {
       var imageName = nodeSettings["icon"] || "generic24.png";
-      return Core.url("/img/icons/camel/" + imageName);
+      return Core.url("img/icons/camel/" + imageName);
     } else {
       return null;
     }

--- a/hawtio-web/src/main/webapp/app/camel/js/endpointChooser.ts
+++ b/hawtio-web/src/main/webapp/app/camel/js/endpointChooser.ts
@@ -13,12 +13,12 @@ module Camel {
     bigdata: {
       label: "Big Data",
       endpoints: ["hdfs", "hbase", "lucene", "solr"],
-      endpointIcon: "/img/icons/camel/endpointRepository24.png"
+      endpointIcon: "img/icons/camel/endpointRepository24.png"
     },
     database: {
       label: "Database",
       endpoints: ["couchdb", "elasticsearch", "hbase", "jdbc", "jpa", "hibernate", "mongodb", "mybatis", "sql"],
-      endpointIcon: "/img/icons/camel/endpointRepository24.png"
+      endpointIcon: "img/icons/camel/endpointRepository24.png"
     },
     cloud: {
       label: "Cloud",
@@ -34,7 +34,7 @@ module Camel {
     messaging: {
       label: "Messaging",
       endpoints: ["jms", "activemq", "amqp", "cometd", "cometds", "mqtt", "netty", "vertx", "websocket"],
-      endpointIcon: "/img/icons/camel/endpointQueue24.png"
+      endpointIcon: "img/icons/camel/endpointQueue24.png"
     },
     mobile: {
       label: "Mobile",
@@ -50,7 +50,7 @@ module Camel {
     },
     storage: {
       label: "Storage",
-      endpointIcon: "/img/icons/camel/endpointFolder24.png",
+      endpointIcon: "img/icons/camel/endpointFolder24.png",
       endpoints: ["file", "ftp", "sftp", "scp", "jsch"]
     },
     template: {
@@ -67,7 +67,7 @@ module Camel {
    */
   export var endpointToCategory = {};
 
-  export var endpointIcon = "/img/icons/camel/endpoint24.png";
+  export var endpointIcon = "img/icons/camel/endpoint24.png";
 
   /**
    *  specify custom label & icon properties for endpoint names
@@ -77,112 +77,112 @@ module Camel {
    */
   export var endpointConfigurations = {
     activemq: {
-      icon: "/img/icons/camel/endpoints/activemq24.png"
+      icon: "img/icons/camel/endpoints/activemq24.png"
     },
     atom: {
-      icon: "/img/icons/camel/endpoints/atom24.png"
+      icon: "img/icons/camel/endpoints/atom24.png"
     },
     bean: {
-      icon: "/img/icons/camel/endpoints/bean24.png"
+      icon: "img/icons/camel/endpoints/bean24.png"
     },
     cxf: {
-      icon: "/img/icons/camel/endpoints/cxf24.png"
+      icon: "img/icons/camel/endpoints/cxf24.png"
     },
     cxfrs: {
-      icon: "/img/icons/camel/endpoints/cxfrs24.png"
+      icon: "img/icons/camel/endpoints/cxfrs24.png"
     },
     ejb: {
-      icon: "/img/icons/camel/endpoints/ejb24.png"
+      icon: "img/icons/camel/endpoints/ejb24.png"
     },
     facebook: {
-      icon: "/img/icons/camel/endpoints/facebook24.jpg"
+      icon: "img/icons/camel/endpoints/facebook24.jpg"
     },
     file: {
-      icon: "/img/icons/camel/endpoints/file24.png"
+      icon: "img/icons/camel/endpoints/file24.png"
     },
     ftp: {
-      icon: "/img/icons/camel/endpoints/ftp24.png"
+      icon: "img/icons/camel/endpoints/ftp24.png"
     },
     ftps: {
-      icon: "/img/icons/camel/endpoints/ftps24.png"
+      icon: "img/icons/camel/endpoints/ftps24.png"
     },
     imap: {
-      icon: "/img/icons/camel/endpoints/imap24.png"
+      icon: "img/icons/camel/endpoints/imap24.png"
     },
     imaps: {
-      icon: "/img/icons/camel/endpoints/imaps24.png"
+      icon: "img/icons/camel/endpoints/imaps24.png"
     },
     jdbc: {
-      icon: "/img/icons/camel/endpoints/jdbc24.png"
+      icon: "img/icons/camel/endpoints/jdbc24.png"
     },
     jms: {
-      icon: "/img/icons/camel/endpoints/jms24.png"
+      icon: "img/icons/camel/endpoints/jms24.png"
     },
     language: {
-      icon: "/img/icons/camel/endpoints/language24.png"
+      icon: "img/icons/camel/endpoints/language24.png"
     },
     linkedin: {
-      icon: "/img/icons/camel/endpoints/linkedin24.png"
+      icon: "img/icons/camel/endpoints/linkedin24.png"
     },
     log: {
-      icon: "/img/icons/camel/endpoints/log24.png"
+      icon: "img/icons/camel/endpoints/log24.png"
     },
     mqtt: {
-      icon: "/img/icons/camel/endpoints/mqtt24.png"
+      icon: "img/icons/camel/endpoints/mqtt24.png"
     },
     pop3: {
-      icon: "/img/icons/camel/endpoints/pop324.png"
+      icon: "img/icons/camel/endpoints/pop324.png"
     },
     pop3s: {
-      icon: "/img/icons/camel/endpoints/pop3s24.png"
+      icon: "img/icons/camel/endpoints/pop3s24.png"
     },
     quartz: {
-      icon: "/img/icons/camel/endpoints/quartz24.png"
+      icon: "img/icons/camel/endpoints/quartz24.png"
     },
     quartz2: {
-      icon: "/img/icons/camel/endpoints/quartz224.png"
+      icon: "img/icons/camel/endpoints/quartz224.png"
     },
     rss: {
-      icon: "/img/icons/camel/endpoints/rss24.png"
+      icon: "img/icons/camel/endpoints/rss24.png"
     },
     salesforce: {
-      icon: "/img/icons/camel/endpoints/salesForce24.png"
+      icon: "img/icons/camel/endpoints/salesForce24.png"
     },
     sap: {
-      icon: "/img/icons/camel/endpoints/SAP24.png"
+      icon: "img/icons/camel/endpoints/SAP24.png"
     },
     "sap-netweaver": {
-      icon: "/img/icons/camel/endpoints/SAPNetweaver24.jpg"
+      icon: "img/icons/camel/endpoints/SAPNetweaver24.jpg"
     },
     servlet: {
-      icon: "/img/icons/camel/endpoints/servlet24.png"
+      icon: "img/icons/camel/endpoints/servlet24.png"
     },
     sftp: {
-      icon: "/img/icons/camel/endpoints/sftp24.png"
+      icon: "img/icons/camel/endpoints/sftp24.png"
     },
     smtp: {
-      icon: "/img/icons/camel/endpoints/smtp24.png"
+      icon: "img/icons/camel/endpoints/smtp24.png"
     },
     smtps: {
-      icon: "/img/icons/camel/endpoints/smtps24.png"
+      icon: "img/icons/camel/endpoints/smtps24.png"
     },
     snmp: {
-      icon: "/img/icons/camel/endpoints/snmp24.png"
+      icon: "img/icons/camel/endpoints/snmp24.png"
     },
     sql: {
-      icon: "/img/icons/camel/endpoints/sql24.png"
+      icon: "img/icons/camel/endpoints/sql24.png"
     },
     timer: {
-      icon: "/img/icons/camel/endpoints/timer24.png"
+      icon: "img/icons/camel/endpoints/timer24.png"
     },
     twitter: {
-      icon: "/img/icons/camel/endpoints/twitter24.png"
+      icon: "img/icons/camel/endpoints/twitter24.png"
     },
     weather: {
-      icon: "/img/icons/camel/endpoints/weather24.jpg"
+      icon: "img/icons/camel/endpoints/weather24.jpg"
     },
     xslt: {
-      icon: "/img/icons/camel/endpoints/xslt24.jpg"
+      icon: "img/icons/camel/endpoints/xslt24.jpg"
     }
   };
 

--- a/hawtio-web/src/main/webapp/app/camel/js/propertiesComponent.ts
+++ b/hawtio-web/src/main/webapp/app/camel/js/propertiesComponent.ts
@@ -126,7 +126,7 @@ module Camel {
         $scope.model.title = $scope.componentName;
         $scope.model.description = $scope.model.component.description;
         // TODO: look for specific component icon,
-        $scope.icon = Core.url("/img/icons/camel/endpoint24.png");
+        $scope.icon = Core.url("img/icons/camel/endpoint24.png");
 
         // grab all values form the model as they are the current data we need to add to node data (not all properties has a value)
         $scope.nodeData = {};

--- a/hawtio-web/src/main/webapp/app/camel/js/propertiesDataFormat.ts
+++ b/hawtio-web/src/main/webapp/app/camel/js/propertiesDataFormat.ts
@@ -116,7 +116,7 @@ module Camel {
         $scope.model.title = $scope.model.dataformat.title  + " (" + $scope.model.dataformat.name + ")";
         $scope.model.description = $scope.model.dataformat.description;
         // TODO: look for specific component icon,
-        $scope.icon = Core.url("/img/icons/camel/marshal24.png");
+        $scope.icon = Core.url("img/icons/camel/marshal24.png");
 
         // grab all values form the model as they are the current data we need to add to node data (not all properties has a value)
         $scope.nodeData = {};

--- a/hawtio-web/src/main/webapp/app/camel/js/propertiesEndpoint.ts
+++ b/hawtio-web/src/main/webapp/app/camel/js/propertiesEndpoint.ts
@@ -131,7 +131,7 @@ module Camel {
         $scope.model.title = $scope.endpointUrl;
         $scope.model.description = $scope.model.component.description;
         // TODO: look for specific endpoint icon,
-        $scope.icon = Core.url("/img/icons/camel/endpoint24.png");
+        $scope.icon = Core.url("img/icons/camel/endpoint24.png");
 
         // grab all values form the model as they are the current data we need to add to node data (not all properties has a value)
         $scope.nodeData = {};


### PR DESCRIPTION
This commit updates all icon image references to use relative paths. This makes sure that icon images can be properly requested even when running hawtio with a custom context path.

This issue was found when running Spring Boot and hawtio with a custom context path. All images in the "Route Diagram" tab were not rendered properly, because they were requested using absolute paths starting with `/img/`.