### PR TITLE
Use Camel version property from parent

### DIFF
--- a/hawtio-sample-springboot/pom.xml
+++ b/hawtio-sample-springboot/pom.xml
@@ -14,10 +14,6 @@
   <description>hawtio :: Sample Spring Boot process</description>
   <packaging>war</packaging>
 
-  <properties>
-    <camel-version>2.19.2</camel-version>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
The Spring Boot sample should use the same Camel version as configured in the parent.