### PR TITLE
2.0.x -- allow using SSL by specifying a keyStore and keyStorePass form embedded hawtio

### DIFF
--- a/hawtio-embedded/pom.xml
+++ b/hawtio-embedded/pom.xml
@@ -17,6 +17,11 @@
       <artifactId>jetty-webapp</artifactId>
       <version>${jetty-version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>${jetty-version}</version>
+    </dependency>
 
     <!-- logging -->
     <dependency>

--- a/hawtio-embedded/src/main/java/io/hawt/embedded/Main.java
+++ b/hawtio-embedded/src/main/java/io/hawt/embedded/Main.java
@@ -21,10 +21,15 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.log.Slf4jLog;
 import org.eclipse.jetty.webapp.WebAppContext;
 
@@ -82,7 +87,61 @@ public class Main {
         HandlerCollection handlers = new HandlerCollection();
         handlers.setServer(server);
         server.setHandler(handlers);
-
+<<<<<<< HEAD
+    String scheme="http";
+    if (null != options.getKeyStore()) {
+        System.out.println("Configuring SSL");
+        SslContextFactory sslcontf = new SslContextFactory();
+        HttpConfiguration httpconf = new HttpConfiguration();
+        sslcontf.setKeyStorePath(options.getKeyStore());
+                if (null != options.getKeyStorePass()){
+            sslcontf.setKeyStorePassword(options.getKeyStorePass());
+                } else {
+                    System.out.println("Attempting to open keystore with no password...");
+                }
+        try(ServerConnector sslconn = new ServerConnector(server, new SslConnectionFactory(sslcontf, "http/1.1"), new HttpConnectionFactory(httpconf));) {
+            sslconn.setPort(options.getPort());
+            server.setConnectors(new Connector[] { sslconn });
+            
+        }
+    scheme="https";
+    }
+    String sysScheme = System.getProperty("hawtio.redirect.scheme");
+    if (null == sysScheme  ) {
+        System.out.println("Implicitly setting Scheme = "+scheme);
+        System.setProperty("hawtio.redirect.scheme", scheme);
+    } else {
+        System.out.println("Scheme Was Set Explicitly To = "+scheme);
+        scheme = sysScheme;
+    }
+=======
+    String scheme="http";
+    if (null != options.getKeyStore()) {
+        System.out.println("Configuring SSL");
+        SslContextFactory sslcontf = new SslContextFactory();
+        HttpConfiguration httpconf = new HttpConfiguration();
+        sslcontf.setKeyStorePath(options.getKeyStore());
+                if (null != options.getKeyStorePass()){
+            sslcontf.setKeyStorePassword(options.getKeyStorePass());
+                } else {
+                    System.out.println("Attempting to open keystore with no password...");
+                }
+        try(ServerConnector sslconn = new ServerConnector(server, new SslConnectionFactory(sslcontf, "http/1.1"), new HttpConnectionFactory(httpconf));) {
+            sslconn.setPort(options.getPort());
+            server.setConnectors(new Connector[] { sslconn });
+            
+        }
+    scheme="https";
+    }
+    String sysScheme = System.getProperty("hawtio.redirect.scheme");
+    if (null == sysScheme  ) {
+        System.out.println("Implicitly setting Scheme = "+scheme);
+        System.setProperty("hawtio.redirect.scheme", scheme);
+    } else {
+        System.out.println("Scheme Was Set Explicitly To = "+scheme);
+        scheme = sysScheme;
+    }
+>>>>>>> us20xx
         WebAppContext webapp = new WebAppContext();
         webapp.setServer(server);
         webapp.setContextPath(options.getContextPath());
@@ -96,6 +155,7 @@ public class Main {
         webapp.setWar(war);
         webapp.setParentLoaderPriority(true);
         webapp.setLogUrlOnStart(true);
+        webapp.setInitParameter("scheme", scheme);
         webapp.setExtraClasspath(options.getExtraClassPath());
 
         // lets set a temporary directory so jetty doesn't bork if some process zaps /tmp/*
@@ -126,7 +186,7 @@ public class Main {
             System.out.println("hawtio: Don't cha wish your console was hawt like me!");
             System.out.println("=====================================================");
             System.out.println();
-            System.out.println("http://localhost:" + options.getPort() + options.getContextPath());
+            System.out.println(scheme+"://localhost:" + options.getPort() + options.getContextPath());
             System.out.println();
         }
 

--- a/hawtio-embedded/src/main/java/io/hawt/embedded/Options.java
+++ b/hawtio-embedded/src/main/java/io/hawt/embedded/Options.java
@@ -35,6 +35,8 @@ public class Options {
     private boolean help;
     private boolean jointServerThread;
     private boolean openUrl = true;
+    private String keyStore = null;
+    private String keyStorePass = null;
 
     private abstract class Option {
         private String abbreviation;
@@ -166,6 +168,16 @@ public class Options {
                 openUrl = Boolean.valueOf(parameter);
             }
         });
+        addOption(new ParameterOption("ks", "keyStore", "JKS keyStore with the keys for https") {
+            protected void doProcess(String arg, String parameter, LinkedList<String> remainingArgs) {
+                keyStore = parameter;
+            }
+        });
+        addOption(new ParameterOption("kp", "keyStorePass", "password for the JKS keyStore with the keys for https") {
+            protected void doProcess(String arg, String parameter, LinkedList<String> remainingArgs) {
+                keyStorePass = parameter;
+            }
+        });
 
     }
 
@@ -206,6 +218,12 @@ public class Options {
         }
         if (plugins != null) {
             sb.append("\n\tplugins=").append(plugins);
+        }
+        if (keyStore != null) {
+            sb.append("\n\tkeyStore=").append(keyStore);
+        }
+        if (keyStorePass != null) {
+            sb.append("\n\tkeyStore=").append(keyStorePass);
         }
         sb.append("\n\topenUrl=").append(openUrl);
         sb.append("\n\tjointServerThread=").append(jointServerThread);
@@ -312,5 +330,16 @@ public class Options {
     public boolean isHelp() {
         return help;
     }
-
+    public String getKeyStore(){
+        return keyStore;
+    }
+    public void setKeyStore(String keyStore){
+        this.keyStore=keyStore;
+    }
+    public String getKeyStorePass(){
+        return keyStorePass;
+    }
+    public void setKeyStorePass(String keyStorePass){
+        this.keyStorePass=keyStorePass;
+    }
 }

--- a/hawtio-system/src/main/java/io/hawt/web/auth/LoginRedirectFilter.java
+++ b/hawtio-system/src/main/java/io/hawt/web/auth/LoginRedirectFilter.java
@@ -35,7 +35,7 @@ public class LoginRedirectFilter implements Filter {
         HttpServletResponse httpResponse = (HttpServletResponse) response;
         HttpSession session = httpRequest.getSession(false);
         String path = httpRequest.getServletPath();
-
+        
         if (authConfiguration.isEnabled() && !authConfiguration.isKeycloakEnabled()
             && !isAuthenticated(session) && isSecuredPath(path)) {
             redirect(httpRequest, httpResponse);
@@ -49,7 +49,28 @@ public class LoginRedirectFilter implements Filter {
     }
 
     private void redirect(HttpServletRequest httpRequest, HttpServletResponse httpResponse) throws IOException {
-        httpResponse.sendRedirect(httpRequest.getContextPath() + AuthenticationConfiguration.LOGIN_URL);
+<<<<<<< HEAD
+        String schem=httpRequest.getServletContext().getInitParameter("scheme");
+        if (null == schem) {
+                System.out.println ("scheme is Null, using default");
+            schem = "http";
+        }
+        
+        System.out.println(schem+" -- LoginRedirectFilter");
+        String portstr = ":"+httpRequest.getServerPort();
+        String redirURL=schem+"://"+httpRequest.getServerName()+portstr+httpRequest.getContextPath() + AuthenticationConfiguration.LOGIN_URL;
+=======
+        String schem=httpRequest.getServletContext().getInitParameter("scheme");
+        if (null == schem) {
+                System.out.println ("scheme is Null, using default");
+            schem = "http";
+        }
+        
+        System.out.println(schem+" -- LoginRedirectFilter");
+        String portstr = ":"+httpRequest.getServerPort();
+        String redirURL=schem+"://"+httpRequest.getServerName()+portstr+httpRequest.getContextPath() + AuthenticationConfiguration.LOGIN_URL;
+>>>>>>> us20xx
+        httpResponse.sendRedirect(redirURL);
     }
 
     List<String> convertCsvToList(String unsecuredPaths) {

--- a/hawtio-system/src/main/java/io/hawt/web/auth/LoginServlet.java
+++ b/hawtio-system/src/main/java/io/hawt/web/auth/LoginServlet.java
@@ -76,7 +76,22 @@ public class LoginServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         if (authConfiguration.isKeycloakEnabled()) {
-            response.sendRedirect(request.getContextPath() + "/");
+<<<<<<< HEAD
+            String schem=request.getServletContext().getInitParameter("scheme");
+            if (null == schem) {
+                schem = "http";
+            }
+            System.out.println(schem+"-- LoginServlet");
+            String redir = schem+request.getServerName()+":"+request.getServerPort()+request.getContextPath()+"/";
+=======
+            String schem=request.getServletContext().getInitParameter("scheme");
+            if (null == schem) {
+                schem = "http";
+            }
+            System.out.println(schem+"-- LoginServlet");
+            String redir = schem+request.getServerName()+":"+request.getServerPort()+request.getContextPath()+"/";
+>>>>>>> us20xx
+            response.sendRedirect(redir);
         } else {
             request.getRequestDispatcher("/login.html").forward(request, response);
         }

--- a/hawtio-system/src/main/java/io/hawt/web/auth/LogoutServlet.java
+++ b/hawtio-system/src/main/java/io/hawt/web/auth/LogoutServlet.java
@@ -40,7 +40,21 @@ public class LogoutServlet extends HttpServlet {
             session.invalidate();
         }
         request.logout();
-        response.sendRedirect(request.getContextPath() + AuthenticationConfiguration.LOGIN_URL);
+<<<<<<< HEAD
+        String schem=request.getServletContext().getInitParameter("scheme");
+        if (null == schem) {
+            schem = "http";
+        }
+        System.out.println(schem+" --logoutservlet");
+=======
+        String schem=request.getServletContext().getInitParameter("scheme");
+        if (null == schem) {
+            schem = "http";
+        }
+        System.out.println(schem+" --logoutservlet");
+>>>>>>> us20xx
+        String redir = schem+request.getServerName()+":"+request.getServerPort()+request.getContextPath()+AuthenticationConfiguration.LOGIN_URL;
+        response.sendRedirect(redir);
     }
 
 }


### PR DESCRIPTION
SSL is already available via container configuration for Hawtio running in external Servlet Containers (such as tomcat, or a managed Jetty instance), but not for embedded use.  

This patch adds support for SSL using embedded Jetty. 

I needed this for one of my own projects, and decided to offer this upstream. 

So far the only remaining issue is that the redirect from "https://host:port/hawtio" redirects to "http://host:port/hawtio/" instead of "https://host:port/hawtio".  

Other redirects (such as the ones to login, if authentication is enabled) work properly.  