### PR TITLE
chore: Use spring-boot-starter-undertow instead of jetty

### DIFF
--- a/examples/springboot-authentication/pom.xml
+++ b/examples/springboot-authentication/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-jetty</artifactId>
+      <artifactId>spring-boot-starter-undertow</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
@tadayosi I assume this change is fine? The springboot-authentication quickstart seems to work fine with Undertow, and it brings it into line with the normal springboot quickstart.