### PR TITLE
Fixes hawtio not configured correctly when all actuators are exposed

### DIFF
--- a/platforms/springboot/src/integration-test/java/io/hawt/springboot/HawtioSpringBootExposedEndpointIT.java
+++ b/platforms/springboot/src/integration-test/java/io/hawt/springboot/HawtioSpringBootExposedEndpointIT.java
@@ -17,12 +17,18 @@ public class HawtioSpringBootExposedEndpointIT {
     public void testStringListProperty() {
         contextRunner.withPropertyValues("management.endpoints.web.exposure.include=hawtio,jolokia,foo")
             .run((context) -> assertThat(context).hasBean("foo"));
+
+        contextRunner.withPropertyValues("management.endpoints.web.exposure.include=*")
+            .run((context) -> assertThat(context).hasBean("foo"));
     }
 
     @Test
     public void testStringArrayProperty() {
         contextRunner.withPropertyValues("management.endpoints.web.exposure.include[0]=hawtio",
             "management.endpoints.web.exposure.include[1]=jolokia", "management.endpoints.web.exposure.include[2]=foo")
+            .run((context) -> assertThat(context).hasBean("foo"));
+
+        contextRunner.withPropertyValues("management.endpoints.web.exposure.include[0]=*")
             .run((context) -> assertThat(context).hasBean("foo"));
     }
 

--- a/platforms/springboot/src/main/java/io/hawt/springboot/ExposedEndpoint.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/ExposedEndpoint.java
@@ -26,7 +26,7 @@ public class ExposedEndpoint implements Condition {
             Environment environment = context.getEnvironment();
             BindResult<List<String>> property = Binder.get(environment).bind(WEB_EXPOSURE_INCLUDE, STRING_LIST);
             List<String> exposedEndpoints = property.orElse(Collections.emptyList());
-            return exposedEndpoints.contains(endpointName);
+            return exposedEndpoints.contains(endpointName) || exposedEndpoints.contains("*");
         }
 
         return false;


### PR DESCRIPTION
Currently when setting `management.endpoints.web.exposure.include=*` in application.properties to expose all available Spring Actuators, `@ConditionalOnExposedEndpoint(name = "jolokia")` evaluates to `false` which prevents initialization of `HawtioManagementConfiguration#hawtioUrlMapping(..)` and `HawtioManagementConfiguration#authenticationFilter(..)`.