### PR TITLE
#2618 Support for OSGi R7 Pax Logging

### DIFF
--- a/hawtio-log-osgi/pom.xml
+++ b/hawtio-log-osgi/pom.xml
@@ -76,6 +76,7 @@
               org.osgi.framework;version="[1.5,2)",
               org.osgi.framework.wiring;version="[1.0,2)",
               org.apache.karaf.log.core;version="[3,5)",
+              org.ops4j.pax.logging.spi;version="[1.8.5,3)",
               *
             </Import-Package>
             <Export-Package />


### PR DESCRIPTION
Resolves dependencies on OSGi R7 containers like Karaf 4.3.0