### PR TITLE
Specify signature for dumpAllThreads operation

### DIFF
--- a/hawtio-web/src/main/webapp/app/threads/js/threads.ts
+++ b/hawtio-web/src/main/webapp/app/threads/js/threads.ts
@@ -212,7 +212,7 @@ module Threads {
         Core.register(jolokia, $scope, {
           type: 'exec',
           mbean: Threads.mbean,
-          operation: 'dumpAllThreads',
+          operation: 'dumpAllThreads(boolean,boolean)',
           arguments: [$scope.support.objectMonitorUsageSupported, $scope.support.synchronizerUsageSupported]
         }, onSuccess(render));
 


### PR DESCRIPTION
In Java 11, there are now two overloads for this operation.
Jolokia will thus require you to specify the overload and throw an exception if you don't.
This patch fixes that.

Whether this issue is still present in 2.x, I don't know.
I'm only using hawtio through ActiveMQ Artemis.
Once this is merged and released, someone with an Apache JIRA account needs to open an issue telling them to upgrade.