### PR TITLE
exclude-log4j-from-hawtio-wildfly-war

### DIFF
--- a/platforms/wildfly/pom.xml
+++ b/platforms/wildfly/pom.xml
@@ -54,7 +54,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
         <configuration>
-          <packagingExcludes>**/lib/slf4j*.jar,**/lib/commons-logging-*.jar,**/classes/log4j.properties,**/lib/netty-*.jar,**/lib/plexus-classworlds-*.jar,**/lib/plexus-component-annotations-*.jar,**/lib/plexus-interpolation-*.jar,**/lib/plexus-utils-*.jar,**/lib/wagon-ahc-*.jar,**/lib/wagon-provider-api-*.jar,**/lib/xbean-reflect-*.jar</packagingExcludes>
+          <packagingExcludes>**/lib/log4j*.jar,**/lib/slf4j*.jar,**/lib/commons-logging-*.jar,**/classes/log4j.properties,**/lib/netty-*.jar,**/lib/plexus-classworlds-*.jar,**/lib/plexus-component-annotations-*.jar,**/lib/plexus-interpolation-*.jar,**/lib/plexus-utils-*.jar,**/lib/wagon-ahc-*.jar,**/lib/wagon-provider-api-*.jar,**/lib/xbean-reflect-*.jar</packagingExcludes>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>


### PR DESCRIPTION
Log4j shows up in QWASP Dependency Check report for CVE-2019-17571.

As Wildfly provides an implementation of log4j 1.x which addresses this problem the jar is not needed in the WAR.