### PR TITLE
[#2687] Update bootstrap to 3.4.1 to address CVEs

### DIFF
--- a/hawtio-console-assembly/app/package.json
+++ b/hawtio-console-assembly/app/package.json
@@ -10,7 +10,7 @@
   "resolutions": {
     "angular-ui-bootstrap": "2.5.6",
     "jquery": "2.2.4",
-    "bootstrap": "3.3.7",
+    "bootstrap": "3.4.1",
     "bootstrap-select": "1.12.4",
     "moment": "2.21.0",
     "strip-ansi": "4.0.0",

--- a/hawtio-console-assembly/app/yarn.lock
+++ b/hawtio-console-assembly/app/yarn.lock
@@ -599,10 +599,10 @@ bootstrap-touchspin@~3.1.1:
   resolved "https://registry.yarnpkg.com/bootstrap-touchspin/-/bootstrap-touchspin-3.1.1.tgz#9779deac72aaf577e5e762b8512c747c871d9597"
   integrity sha1-l3nerHKq9Xfl52K4USx0fIcdlZc=
 
-bootstrap@3.3.7, bootstrap@3.4.1, bootstrap@^3.3, bootstrap@^3.4.1, bootstrap@~3.4.1:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
-  integrity sha1-WjiTlFSfIzMIdaOxUGVldPip63E=
+bootstrap@3.4.1, bootstrap@^3.3, bootstrap@^3.4.1, bootstrap@~3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
+  integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
- CVE-2018-14041
- CVE-2018-14042
- CVE-2019-8331