### PR TITLE
Update pom.xml to upgrade log4j2 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <karaf-version-range>[4.0,5)</karaf-version-range>
     <keycloak-version>11.0.2</keycloak-version>
     <log4j-version>1.2.17</log4j-version>
-    <log4j2-version>2.14.0</log4j2-version>
+    <log4j2-version>2.15.0</log4j2-version>
     <maven-antrun-plugin-version>1.8</maven-antrun-plugin-version>
     <maven-bundle-plugin-version>3.0.1</maven-bundle-plugin-version>
     <maven-failsafe-plugin-version>3.0.0-M1</maven-failsafe-plugin-version>


### PR DESCRIPTION
from 2.14 to 2.15 to get the Log4shell CVE fix.
https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2314720