### PR TITLE
bump log4j2 again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <karaf-version-range>[4.0,5)</karaf-version-range>
     <keycloak-version>11.0.2</keycloak-version>
     <log4j-version>1.2.17</log4j-version>
-    <log4j2-version>2.15.0</log4j2-version>
+    <log4j2-version>2.16.0</log4j2-version>
     <maven-antrun-plugin-version>1.8</maven-antrun-plugin-version>
     <maven-bundle-plugin-version>3.0.1</maven-bundle-plugin-version>
     <maven-failsafe-plugin-version>3.0.0-M1</maven-failsafe-plugin-version>


### PR DESCRIPTION
because of:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228

this addresses issue #2712 