### PR TITLE
add support for Bearer Token based Authentication

### DIFF
--- a/hawtio-system/src/main/java/io/hawt/system/Authenticator.java
+++ b/hawtio-system/src/main/java/io/hawt/system/Authenticator.java
@@ -45,6 +45,7 @@ public class Authenticator {
 
     public static final String HEADER_AUTHORIZATION = "Authorization";
     public static final String AUTHENTICATION_SCHEME_BASIC = "Basic";
+	public static final String AUTHENTICATION_SCHEME_BEARER = "Bearer";
     public static final String ATTRIBUTE_X509_CERTIFICATE = "javax.servlet.request.X509Certificate";
 
     private static Boolean websphereDetected;
@@ -117,6 +118,12 @@ public class Authenticator {
             String password = decoded.substring(delimiter + 1);
             callback.accept(username, password);
         }
+
+		if (authType.equalsIgnoreCase(AUTHENTICATION_SCHEME_BEARER)) {
+			String username = "token";
+			String password = authInfo;
+			callback.accept(username, password);
+		}
     }
 
     public boolean isUsernamePasswordSet() {


### PR DESCRIPTION
I tried to secure hawt.io console with keycloak based on hawt.io documentation but also based on the example of activemq artemis. Unfortunately i was not able to make it working and therefore started debugging. I found the problem in class io.hawt.system.Authenticator which does only support Basic Http Header Authorization but not the Bearer token. I have extended the class to make this working.
It seems that there is also a corresponding problem in the javascript code because even if i am redirected to keycloak authentication page the token is never passed with the request. FOr me so far this is no problem because i do authentication in a proxy service which will then pass the token properly the hawtio server.