### PR TITLE
chore: updated hawtio-integration version to 5.0.0

### DIFF
--- a/hawtio-console-assembly/app/package.json
+++ b/hawtio-console-assembly/app/package.json
@@ -2,7 +2,7 @@
   "name": "@hawtio/console-assembly",
   "version": "2.0.0",
   "dependencies": {
-    "@hawtio/integration": "^4.16.7",
+    "@hawtio/integration": "^5.0.0",
     "@hawtio/oauth": "^4.13.7",
     "keycloak-js": "3.4.3"
   },

--- a/hawtio-console-assembly/app/yarn.lock
+++ b/hawtio-console-assembly/app/yarn.lock
@@ -33,10 +33,10 @@
     typescript "^3.0.3"
     urijs "1.19.0"
 
-"@hawtio/integration@^4.16.7":
-  version "4.16.7"
-  resolved "https://registry.yarnpkg.com/@hawtio/integration/-/integration-4.16.7.tgz#f8abe2e9092ce878beb1dc86bd17467197fb11ff"
-  integrity sha512-DuhA7DVJ46E7z9VTBhx7AiSle/lwCnmWyH7gr/WsEjHC6Yde59gxf2rwX+YWJIgGKJBxL+5Aoxzo/kTFmNQ2gQ==
+"@hawtio/integration@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@hawtio/integration/-/integration-5.0.0.tgz#2293a76f49b8bcd56cfdfb2d75f6a4919d88dac3"
+  integrity sha512-ny68X5Q9ohNjM8Xvun4WPnsaE5VUI3PcUa4HxIiK8MfIERETbx9dJgkxjje8Ua6TVQLWAoXkUqwXzgi9zzs8SA==
   dependencies:
     "@hawtio/core" "^4.16.0"
     "@types/angular-cookies" "^1.4.5"


### PR DESCRIPTION
In response to the community user's issue : https://github.com/hawtio/hawtio-integration/issues/131 ;we have updated the upstream camel version to "3.14.2"  in the PR: https://github.com/hawtio/hawtio-integration/pull/138.

This closes the issue : https://github.com/hawtio/hawtio/issues/2736