### PR TITLE
Fix NPE in FlightRecordingDownloadFacade

### DIFF
--- a/hawtio-system/src/main/java/io/hawt/web/filters/FlightRecordingDownloadFacade.java
+++ b/hawtio-system/src/main/java/io/hawt/web/filters/FlightRecordingDownloadFacade.java
@@ -168,7 +168,7 @@ public class FlightRecordingDownloadFacade implements Filter {
         }
 
         private String replaceInPath(String servletPath) {
-            return servletPath.replace(this.replaceFrom, this.replaceTo);
+            return servletPath == null ? null : servletPath.replace(this.replaceFrom, this.replaceTo);
         }
 
         @Override


### PR DESCRIPTION
When `super.getPathInfo()` be null, this Request Wrapper will throw an NPE.