### PR TITLE
chore: updated hawtio-integration version to 5.0.2

### DIFF
--- a/hawtio-console-assembly/app/package.json
+++ b/hawtio-console-assembly/app/package.json
@@ -2,7 +2,7 @@
   "name": "@hawtio/console-assembly",
   "version": "2.0.0",
   "dependencies": {
-    "@hawtio/integration": "^5.0.1",
+    "@hawtio/integration": "^5.0.2",
     "@hawtio/oauth": "^4.13.8",
     "keycloak-js": "3.4.3"
   },

--- a/hawtio-console-assembly/app/yarn.lock
+++ b/hawtio-console-assembly/app/yarn.lock
@@ -33,10 +33,10 @@
     typescript "^3.0.3"
     urijs "1.19.0"
 
-"@hawtio/integration@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@hawtio/integration/-/integration-5.0.1.tgz#1647757ee94175868eb506ff6e497a5aa5d67bc6"
-  integrity sha512-UtJcogwsGVmMAqEXgq2yR7T9/M4ndV9632D6ltQzEsFe0W86X/93TfXY6PXkE5Jo557FLP+QpuHo6xHYHYLGAw==
+"@hawtio/integration@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@hawtio/integration/-/integration-5.0.2.tgz#c0281750d31c9cb75109e156735e2f07190d847d"
+  integrity sha512-Mw1nSKFVDlcqvJF5ocXbqzbtDx9LP03/yNzElW8MViUtXqtygg186JaMMJT3+6L0syfXRSQrS1HChtmPkui5iA==
   dependencies:
     "@hawtio/core" "^4.16.1"
     "@types/angular-cookies" "^1.4.5"


### PR DESCRIPTION
This new version enables the option to view the entire thread Dump and closes the issue https://github.com/hawtio/hawtio-integration/issues/142.