### PR TITLE
fix(system): ENTESB-19673 switch X-Frame-Options default to DENY

### DIFF
--- a/hawtio-system/src/main/java/io/hawt/web/filters/HttpHeaderFilter.java
+++ b/hawtio-system/src/main/java/io/hawt/web/filters/HttpHeaderFilter.java
@@ -21,6 +21,9 @@ public abstract class HttpHeaderFilter implements Filter {
 
     private static final transient Logger LOG = LoggerFactory.getLogger(HttpHeaderFilter.class);
 
+    public static final String ALLOW_X_FRAME_SAME_ORIGIN = "http.allowXFrameSameOrigin";
+    public static final String HAWTIO_ALLOW_X_FRAME_SAME_ORIGIN = "hawtio." + ALLOW_X_FRAME_SAME_ORIGIN;
+
     private ConfigManager configManager;
 
     public HttpHeaderFilter() {
@@ -48,5 +51,10 @@ public abstract class HttpHeaderFilter implements Filter {
 
     protected String getConfigParameter(String key) {
         return configManager.get(key, null);
+    }
+
+    protected boolean isXFrameSameOriginAllowed() {
+        String allow = getConfigParameter(ALLOW_X_FRAME_SAME_ORIGIN);
+        return Boolean.parseBoolean(allow);
     }
 }

--- a/hawtio-system/src/main/java/io/hawt/web/filters/XFrameOptionsFilter.java
+++ b/hawtio-system/src/main/java/io/hawt/web/filters/XFrameOptionsFilter.java
@@ -1,15 +1,33 @@
 package io.hawt.web.filters;
 
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
  */
 public class XFrameOptionsFilter extends HttpHeaderFilter {
 
+    private static final transient Logger LOG = LoggerFactory.getLogger(XFrameOptionsFilter.class);
+
+    private String headerValue = "DENY";
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        super.init(filterConfig);
+        if (isXFrameSameOriginAllowed()) {
+            headerValue = "SAMEORIGIN";
+        }
+        LOG.debug("X-Frame-Options is configured: {}", headerValue);
+    }
+
     @Override
     protected void addHeaders(HttpServletRequest request, HttpServletResponse response) {
-        response.addHeader("X-Frame-Options", "SAMEORIGIN");
+        response.addHeader("X-Frame-Options", headerValue);
     }
 }

--- a/hawtio-system/src/test/java/io/hawt/web/filters/ContentSecurityPolicyFilterTest.java
+++ b/hawtio-system/src/test/java/io/hawt/web/filters/ContentSecurityPolicyFilterTest.java
@@ -54,7 +54,8 @@ public class ContentSecurityPolicyFilterTest {
         verify(response).addHeader("Content-Security-Policy",
                 "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' ; "
                         + "style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; "
-                        + "connect-src 'self' ; frame-src 'self' ");
+                        + "connect-src 'self' ; frame-src 'self' ; "
+                        + "frame-ancestors 'none'");
     }
 
     @Test
@@ -68,7 +69,8 @@ public class ContentSecurityPolicyFilterTest {
         verify(response).addHeader("Content-Security-Policy",
                 "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:8180; "
                         + "style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; "
-                        + "connect-src 'self' http://localhost:8180; frame-src 'self' http://localhost:8180");
+                        + "connect-src 'self' http://localhost:8180; frame-src 'self' http://localhost:8180; "
+                        + "frame-ancestors 'none'");
     }
 
     @Test
@@ -82,7 +84,8 @@ public class ContentSecurityPolicyFilterTest {
         verify(response).addHeader("Content-Security-Policy",
                 "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:8180; "
                         + "style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; "
-                        + "connect-src 'self' http://localhost:8180; frame-src 'self' http://localhost:8180");
+                        + "connect-src 'self' http://localhost:8180; frame-src 'self' http://localhost:8180; "
+                        + "frame-ancestors 'none'");
     }
 
     @Test
@@ -94,6 +97,21 @@ public class ContentSecurityPolicyFilterTest {
         contentSecurityPolicyFilter.addHeaders(request, response);
         // then
         verify(response).addHeader(eq("Content-Security-Policy"), eq(
-            "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' ; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' ; frame-src 'self' "));
-		}
+            "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' ; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' ; frame-src 'self' ; frame-ancestors 'none'"));
+    }
+
+    @Test
+    public void shouldSetHeaderWithFrameAncestorsSelfWhenConfigParameterIsSet() throws Exception {
+        // given
+        when(configManager.get(HttpHeaderFilter.ALLOW_X_FRAME_SAME_ORIGIN, null)).thenReturn("true");
+        contentSecurityPolicyFilter.init(filterConfig);
+        // when
+        contentSecurityPolicyFilter.addHeaders(request, response);
+        // then
+        verify(response).addHeader("Content-Security-Policy",
+                "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' ; "
+                        + "style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; "
+                        + "connect-src 'self' ; frame-src 'self' ; "
+                        + "frame-ancestors 'self'");
+    }
 }


### PR DESCRIPTION
Now by default Hawtio sets the following HTTP headers:

    X-Frame-Options: DENY
    Content-Security-Policy: frame-ancestors 'none'

Optionally, you can restore the original behaviour by setting the following system property:

    hawtio.http.allowXFrameSameOrigin=true