### PR TITLE
fix(system): ENTESB-19674 set Referrer-Policy to no-referrer by default

### DIFF
--- a/hawtio-base/src/main/webapp/WEB-INF/web.xml
+++ b/hawtio-base/src/main/webapp/WEB-INF/web.xml
@@ -145,6 +145,15 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>ReferrerPolicyFilter</filter-name>
+    <filter-class>io.hawt.web.filters.ReferrerPolicyFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>ReferrerPolicyFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>AuthenticationFilter</filter-name>
     <filter-class>io.hawt.web.auth.AuthenticationFilter</filter-class>
   </filter>

--- a/hawtio-system/src/main/java/io/hawt/web/filters/ReferrerPolicyFilter.java
+++ b/hawtio-system/src/main/java/io/hawt/web/filters/ReferrerPolicyFilter.java
@@ -1,0 +1,37 @@
+package io.hawt.web.filters;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
+ */
+public class ReferrerPolicyFilter extends HttpHeaderFilter {
+
+    private static final transient Logger LOG = LoggerFactory.getLogger(ReferrerPolicyFilter.class);
+
+    public static final String REFERRER_POLICY = "http.referrerPolicy";
+    public static final String HAWTIO_REFERRER_POLICY = "hawtio." + REFERRER_POLICY;
+
+    private String headerValue = "no-referrer";
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        super.init(filterConfig);
+        String policy = getConfigParameter(REFERRER_POLICY);
+        if (policy != null) {
+            headerValue = policy;
+        }
+        LOG.debug("Referrer-Policy is configured: {}", headerValue);
+    }
+
+    @Override
+    protected void addHeaders(HttpServletRequest request, HttpServletResponse response) {
+        response.addHeader("Referrer-Policy", headerValue);
+    }
+}

--- a/hawtio-war/src/main/webapp/WEB-INF/web.xml
+++ b/hawtio-war/src/main/webapp/WEB-INF/web.xml
@@ -145,6 +145,15 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>ReferrerPolicyFilter</filter-name>
+    <filter-class>io.hawt.web.filters.ReferrerPolicyFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>ReferrerPolicyFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>AuthenticationFilter</filter-name>
     <filter-class>io.hawt.web.auth.AuthenticationFilter</filter-class>
   </filter>

--- a/platforms/osgi-war/src/main/webapp/WEB-INF/web.xml
+++ b/platforms/osgi-war/src/main/webapp/WEB-INF/web.xml
@@ -145,6 +145,15 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>ReferrerPolicyFilter</filter-name>
+    <filter-class>io.hawt.web.filters.ReferrerPolicyFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>ReferrerPolicyFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>AuthenticationFilter</filter-name>
     <filter-class>io.hawt.web.auth.AuthenticationFilter</filter-class>
   </filter>

--- a/platforms/springboot/src/main/java/io/hawt/springboot/HawtioManagementConfiguration.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/HawtioManagementConfiguration.java
@@ -28,6 +28,7 @@ import io.hawt.web.filters.CacheHeadersFilter;
 import io.hawt.web.filters.ContentSecurityPolicyFilter;
 import io.hawt.web.filters.FlightRecordingDownloadFacade;
 import io.hawt.web.filters.PublicKeyPinningFilter;
+import io.hawt.web.filters.ReferrerPolicyFilter;
 import io.hawt.web.filters.StrictTransportSecurityFilter;
 import io.hawt.web.filters.XContentTypeOptionsFilter;
 import io.hawt.web.filters.XFrameOptionsFilter;
@@ -178,6 +179,14 @@ public class HawtioManagementConfiguration {
     public FilterRegistrationBean publicKeyPinningFilter() {
         final FilterRegistrationBean<PublicKeyPinningFilter> filter = new FilterRegistrationBean<>();
         filter.setFilter(new PublicKeyPinningFilter());
+        filter.addUrlPatterns(hawtioPath + "/*");
+        return filter;
+    }
+
+    @Bean
+    public FilterRegistrationBean referrerPolicyFilter() {
+        final FilterRegistrationBean<ReferrerPolicyFilter> filter = new FilterRegistrationBean<>();
+        filter.setFilter(new ReferrerPolicyFilter());
         filter.addUrlPatterns(hawtioPath + "/*");
         return filter;
     }

--- a/platforms/wildfly/src/main/webapp/WEB-INF/web.xml
+++ b/platforms/wildfly/src/main/webapp/WEB-INF/web.xml
@@ -132,6 +132,15 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>ReferrerPolicyFilter</filter-name>
+    <filter-class>io.hawt.web.filters.ReferrerPolicyFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>ReferrerPolicyFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>AuthenticationFilter</filter-name>
     <filter-class>io.hawt.web.auth.AuthenticationFilter</filter-class>
   </filter>


### PR DESCRIPTION
Now by default Hawtio sets the following HTTP header:

    Referrer-Policy: no-referrer

Optionally, you can customise the header by setting the following system property:

    hawtio.http.referrerPolicy=...