### PR TITLE
fix(system): ENTESB-19675 disable CORSFilter by default

### DIFF
--- a/hawtio-system/src/main/java/io/hawt/web/filters/CORSFilter.java
+++ b/hawtio-system/src/main/java/io/hawt/web/filters/CORSFilter.java
@@ -1,16 +1,39 @@
 package io.hawt.web.filters;
 
 import java.util.concurrent.TimeUnit;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+ */
 public class CORSFilter extends HttpHeaderFilter {
+
+    private static final transient Logger LOG = LoggerFactory.getLogger(CORSFilter.class);
+
+    public static final String ACCESS_CONTROL_ALLOW_ORIGIN = "http.accessControlAllowOrigin";
+    public static final String HAWTIO_ACCESS_CONTROL_ALLOW_ORIGIN = "hawtio." + ACCESS_CONTROL_ALLOW_ORIGIN;
+
+    private String headerValue = "*";
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        super.init(filterConfig);
+        String origin = getConfigParameter(ACCESS_CONTROL_ALLOW_ORIGIN);
+        if (origin != null) {
+            headerValue = origin;
+        }
+        LOG.debug("Access-Control-Allow-Origin is configured: {}", headerValue);
+    }
 
     @Override
     protected void addHeaders(HttpServletRequest request, HttpServletResponse response) {
-        if (!allowAny()) {
-            return;
-        }
         if ("OPTIONS".equals(request.getMethod())) {
             response.addHeader("Access-Control-Request-Method", "GET, POST, PUT, DELETE");
             String headers = request.getHeader("Access-Control-Request-Headers");
@@ -19,11 +42,6 @@ public class CORSFilter extends HttpHeaderFilter {
             }
             response.addHeader("Access-Control-Max-Age", "" + TimeUnit.DAYS.toSeconds(1));
         }
-        response.addHeader("Access-Control-Allow-Origin", "*");
-    }
-
-    protected boolean allowAny() {
-        // TODO allow configuration...
-        return true;
+        response.addHeader("Access-Control-Allow-Origin", headerValue);
     }
 }

--- a/hawtio-system/src/main/java/io/hawt/web/filters/CORSFilter.java
+++ b/hawtio-system/src/main/java/io/hawt/web/filters/CORSFilter.java
@@ -17,14 +17,24 @@ public class CORSFilter extends HttpHeaderFilter {
 
     private static final transient Logger LOG = LoggerFactory.getLogger(CORSFilter.class);
 
+    public static final String ENABLE_CORS = "http.enableCORS";
+    public static final String HAWTIO_ENABLE_CORS = "hawtio." + ENABLE_CORS;
+
     public static final String ACCESS_CONTROL_ALLOW_ORIGIN = "http.accessControlAllowOrigin";
     public static final String HAWTIO_ACCESS_CONTROL_ALLOW_ORIGIN = "hawtio." + ACCESS_CONTROL_ALLOW_ORIGIN;
 
+    private boolean enabled = false;
     private String headerValue = "*";
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
         super.init(filterConfig);
+        String enableCORS = getConfigParameter(ENABLE_CORS);
+        if (Boolean.parseBoolean(enableCORS)) {
+            enabled = true;
+            LOG.debug("CORS enabled");
+        }
+
         String origin = getConfigParameter(ACCESS_CONTROL_ALLOW_ORIGIN);
         if (origin != null) {
             headerValue = origin;
@@ -34,6 +44,10 @@ public class CORSFilter extends HttpHeaderFilter {
 
     @Override
     protected void addHeaders(HttpServletRequest request, HttpServletResponse response) {
+        if (!enabled) {
+            return;
+        }
+
         if ("OPTIONS".equals(request.getMethod())) {
             response.addHeader("Access-Control-Request-Method", "GET, POST, PUT, DELETE");
             String headers = request.getHeader("Access-Control-Request-Headers");


### PR DESCRIPTION
Now by default Hawtio stops sending the following HTTP header:

      Access-Control-Allow-Origin: ...

Optionally, you can restore the original behaviour by setting the following system property:

      hawtio.http.enableCORS=true

Also when enabled, you can customise the header by setting the following system property:

      hawtio.http.accessControlAllowOrigin=https://example.com