### PR TITLE
[Fix] darwin-arm64 is supported since node 19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <commons-io-version>2.11.0</commons-io-version>
     <commons-logging-version>1.2</commons-logging-version>
     <exec-maven-plugin-version>1.5.0</exec-maven-plugin-version>
-    <frontend-maven-plugin-version>1.6</frontend-maven-plugin-version>
+    <frontend-maven-plugin-version>1.12.1</frontend-maven-plugin-version>
     <guava-version>30.1-jre</guava-version>
     <hamcrest-version>1.3</hamcrest-version>
     <httpclient-version>4.5.13</httpclient-version>


### PR DESCRIPTION
The fix for Mac M1 users

The project tries to install node v14.17.3

`[INFO] Downloading https://nodejs.org/dist/v14.17.3/node-v14.17.3-darwin-arm64.tar.gz to /Users/tsedmik/.m2/repository/com/github/eirslett/node/14.17.3/node-14.17.3-darwin-arm64.tar.gz`

However, darwin-arm64 is supported since Node 19+
https://nodejs.org/dist/v14.17.3/
`[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.6:install-node-and-yarn (install node and yarn) on project hawtio-console-assembly: Could not download Node.js: Got error code 404 from the server. -> [Help 1]`

I updated the `frontend-maven-plugin-version` to 1.12.1