### PR TITLE
[E2E] GitHub Workflow to run E2E per pull req and commit

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,0 +1,32 @@
+name: E2E Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        java: [ '11', '17' ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+      - name: Build & E2E test
+        run: |
+          mvn --batch-mode install -Druntime=springboot -Dtest=RunSpringBootAllTest


### PR DESCRIPTION
A new workflow to run E2E tests per pull req and commits as asked in the https://github.com/hawtio/hawtio/issues/2790

Right now it will trigger E2E tests only on Spring Boot runtime as there are no tests for Quarkus yet.