### PR TITLE
[Workflow] Exclude E2E tests from Test workflow and increase timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
-          <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
+          <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
           <childDelegation>false</childDelegation>
           <useFile>true</useFile>
           <failIfNoTests>false</failIfNoTests>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -138,6 +138,19 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin-version}</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>hawtio-tests-springboot</id>
@@ -147,6 +160,18 @@
           <value>springboot</value>
         </property>
       </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${maven-surefire-plugin-version}</version>
+            <configuration>
+              <skipTests>false</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
       <modules>
         <module>springboot</module>
       </modules>


### PR DESCRIPTION
Before E2E tests were triggered in the Test workflow and caused test execution duplication in both workflows - Test and E2E Tests.

Now E2E tests are triggered only in E2E test workflow.

Also, the timeout in maven surefire was increased as it caused issued before.