### PR TITLE
[E2E Tests] Stabilize open menu tabs method

### DIFF
--- a/tests/utils/src/main/java/io/hawt/tests/utils/pageobjects/pages/HawtioPage.java
+++ b/tests/utils/src/main/java/io/hawt/tests/utils/pageobjects/pages/HawtioPage.java
@@ -2,7 +2,8 @@ package io.hawt.tests.utils.pageobjects.pages;
 
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.enabled;
-import static com.codeborne.selenide.Condition.not;
+import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.hidden;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byXpath;
 import static com.codeborne.selenide.Selenide.$;
@@ -82,17 +83,19 @@ public class HawtioPage {
 
     public <C> C openTab(String tab, Class<C> c) {
         final SelenideElement tabElement = $(byXpath("//a[text()='" + tab + "']"));
+        final SelenideElement moreDropDownMenuElement = $(byXpath("//a[@id='moreDropdown' and normalize-space(text())='More']"));
 
         // if the tab is active, return the page
         if (tabElement.$(byXpath("parent::li")).has(cssClass("active"))) {
             return page(c);
         }
 
-        // if tabs are hidden, expand More dropdown menu
-        if (tabElement.is(not(visible))) {
-            $(byXpath("//a[@id='moreDropdown']")).shouldBe(visible).click();
+        // if More tab is displayed, expand it
+        if (moreDropDownMenuElement.isDisplayed()) {
+            moreDropDownMenuElement.click();
         }
-        tabElement.shouldBe(visible).click();
+
+        tabElement.should(exist).shouldNotBe(hidden).click();
         return page(c);
     }
 }

--- a/tests/utils/src/main/java/io/hawt/tests/utils/pageobjects/pages/quartz/QuartzPage.java
+++ b/tests/utils/src/main/java/io/hawt/tests/utils/pageobjects/pages/quartz/QuartzPage.java
@@ -1,9 +1,17 @@
 package io.hawt.tests.utils.pageobjects.pages.quartz;
 
-import io.hawt.tests.utils.pageobjects.fragments.quartz.QuartzTree;
-import io.hawt.tests.utils.pageobjects.pages.HawtioPage;
+import static com.codeborne.selenide.Condition.cssClass;
+import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.hidden;
+import static com.codeborne.selenide.Selectors.byXpath;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.page;
 
-public class QuartzPage extends HawtioPage {
+import com.codeborne.selenide.SelenideElement;
+
+import io.hawt.tests.utils.pageobjects.fragments.quartz.QuartzTree;
+
+public class QuartzPage {
     private final QuartzTree quartzTree;
 
     public QuartzPage() {
@@ -12,5 +20,17 @@ public class QuartzPage extends HawtioPage {
 
     public QuartzTree quartzTree() {
         return quartzTree;
+    }
+
+    public <C> C openTab(String tab, Class<C> c) {
+        final SelenideElement tabElement = $(byXpath("//a[text()='" + tab + "']"));
+
+        // if the tab is active, return the page
+        if (tabElement.$(byXpath("parent::li")).has(cssClass("active"))) {
+            return page(c);
+        }
+
+        tabElement.should(exist).shouldNotBe(hidden).click();
+        return page(c);
     }
 }


### PR DESCRIPTION
The E2E tests became [flaky](https://github.com/hawtio/hawtio/issues/2815) and most failures were related to one method. By default, the tests are running in a background (headless mode) and most likely there were situations (connectivity issues like delays) when Selenide thought that some menu tabs were hidden under More tab (drop-down menu) and it was waiting for it. It was causing test failures and a job rerun was required. 

With this method deletion the situation should be stabilised.