### PR TITLE
[E2E Tests] Add basic test for Sample Plugin

### DIFF
--- a/tests/springboot/.gitignore
+++ b/tests/springboot/.gitignore
@@ -1,0 +1,2 @@
+# production
+/build

--- a/tests/springboot/src/test/resources/features/plugin/plugin.feature
+++ b/tests/springboot/src/test/resources/features/plugin/plugin.feature
@@ -1,0 +1,7 @@
+Feature: Checking the functionality of Plugin page.
+
+  @springBootAllTest
+  Scenario: Check that Sample Plugin got installed and accessible
+    Given User is on "Sample Plugin" page
+    Then Content section has h1 title "Sample Plugin"
+    And Content section has paragraph "This is a sample Hawtio plugin that is discovered dynamically at runtime."

--- a/tests/utils/src/main/java/io/hawt/tests/utils/pageobjects/pages/plugin/PluginPage.java
+++ b/tests/utils/src/main/java/io/hawt/tests/utils/pageobjects/pages/plugin/PluginPage.java
@@ -1,0 +1,15 @@
+package io.hawt.tests.utils.pageobjects.pages.plugin;
+
+import static com.codeborne.selenide.Condition.exactText;
+import static com.codeborne.selenide.Selenide.$;
+import io.hawt.tests.utils.pageobjects.pages.HawtioPage;
+
+public class PluginPage extends HawtioPage {
+    public void checkTitle(String title) {
+        $("div .pf-c-content h1").shouldHave(exactText(title));
+    }
+
+    public void checkContentParagraph(String content) {
+        $("div .pf-c-content p").shouldHave(exactText(content));
+    }
+}

--- a/tests/utils/src/main/java/io/hawt/tests/utils/stepdefinitions/plugin/PluginStepDefs.java
+++ b/tests/utils/src/main/java/io/hawt/tests/utils/stepdefinitions/plugin/PluginStepDefs.java
@@ -1,0 +1,18 @@
+package io.hawt.tests.utils.stepdefinitions.plugin;
+
+import io.cucumber.java.en.Then;
+import io.hawt.tests.utils.pageobjects.pages.plugin.PluginPage;
+
+public class PluginStepDefs {
+    private final PluginPage pluginPage = new PluginPage();
+
+    @Then("^Content section has h1 title \"([^\"]*)\"$")
+    public void contentSectionHasH1Title(String title) {
+        pluginPage.checkTitle(title);
+    }
+
+    @Then("^Content section has paragraph \"([^\"]*)\"$")
+    public void contentSectionHasParagraph(String content) {
+        pluginPage.checkContentParagraph(content);
+    }
+}


### PR DESCRIPTION
In this MR:

- Basic test checking ability to access the Sample plugin (whether it got installed and got accessed in UI)
- Basic test checking the content view of the Sample plugin (title and paragraph)
- Also, I added a `.gitignore` file into `tests/springboot/` to ignore `/build` directory