### PR TITLE
fix(examples): Add pseudo POM dependency for hawtio-quarkus-deployment to enforce the correct reactor build order

### DIFF
--- a/examples/quarkus/pom.xml
+++ b/examples/quarkus/pom.xml
@@ -109,18 +109,27 @@
       <groupId>io.hawt</groupId>
       <artifactId>hawtio-quarkus</artifactId>
     </dependency>
-    <!-- TODO: deployment is required only for ensuring build order -->
-    <dependency>
-      <groupId>io.hawt</groupId>
-      <artifactId>hawtio-quarkus-deployment</artifactId>
-      <scope>compile</scope>
-    </dependency>
 
     <!-- Testing -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <!-- Minimal test dependencies to *-deployment artifacts for consistent Hawtio project build order -->
+    <dependency>
+      <groupId>io.hawt</groupId>
+      <artifactId>hawtio-quarkus-deployment</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
@tadayosi this is typically how the build order is forced in the camel-quarkus and quarkus projects.