### PR TITLE
[E2E Tests] Camel tree id-s tests and log out stabilization, version updates.

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -15,13 +15,13 @@
   <packaging>pom</packaging>
 
   <properties>
-    <camel-version>3.20.3</camel-version>
+    <camel-version>3.20.5</camel-version>
     <http5-version>5.2.1</http5-version>
-    <guava-version>31.1-jre</guava-version>
+    <guava-version>32.0.0-jre</guava-version>
     <slf4j-version>2.0.7</slf4j-version>
-    <selenium-version>4.9.0</selenium-version>
-    <selenide-version>6.13.1</selenide-version>
-    <cucumber-version>7.12.0</cucumber-version>
+    <selenium-version>4.9.1</selenium-version>
+    <selenide-version>6.15.0</selenide-version>
+    <cucumber-version>7.12.1</cucumber-version>
   </properties>
 
   <modules>

--- a/tests/quarkus/src/test/resources/features/camel/contexts/camel_contexts.feature
+++ b/tests/quarkus/src/test/resources/features/camel/contexts/camel_contexts.feature
@@ -3,7 +3,6 @@ Feature: Checking the changes of states after performing some operation on Camel
 
   Scenario Outline: Check the operations on Camel Context
     Given User is on "Camel" page
-    And User is on Camel Contexts
     And Camel "SampleCamelQuarkus" item has "<initial state>" state in Camel table
     When User selects "SampleCamelQuarkus" item in Camel table
     And User clicks on "<action>" button in Camel table

--- a/tests/springboot/src/test/resources/features/camel/contexts/camel_contexts.feature
+++ b/tests/springboot/src/test/resources/features/camel/contexts/camel_contexts.feature
@@ -3,7 +3,6 @@ Feature: Checking the changes of states after performing some operation on Camel
   @springBootSmokeTest @springBootAllTest
   Scenario Outline: Check the operations on Camel Context
     Given User is on "Camel" page
-    And User is on Camel Contexts
     And Camel "SampleCamel" item has "<initial state>" state in Camel table
     When User selects "SampleCamel" item in Camel table
     And User clicks on "<action>" button in Camel table

--- a/tests/utils/src/main/java/io/hawt/tests/utils/pageobjects/fragments/Panel.java
+++ b/tests/utils/src/main/java/io/hawt/tests/utils/pageobjects/fragments/Panel.java
@@ -31,12 +31,12 @@ public class Panel {
         if (!$(byXpath("//a[contains(text(),'my_htpasswd_provider')]")).is(interactable)) {
             this.openDropDownMenu("#hawtio-header-user-dropdown-toggle");
             // Workaround for Windows machines - sometimes, the Logout button is not loaded properly
-            if ($(byXpath("//a[contains(text(), 'Logout')]")).is(not(interactable))) {
+            if ($(byXpath("//a[contains(text(), 'Log out')]")).is(not(interactable))) {
                 LOG.info("Logout by the direct logout URL");
                 open(getUrlFromParameters() + "/auth/logout");
             } else {
                 LOG.info("Logout from the drop-down menu list");
-                $(byXpath("//a[contains(text(), 'Logout')]")).shouldBe(interactable).click();
+                $(byXpath("//a[contains(text(), 'Log out')]")).shouldBe(interactable).click();
             }
         }
         return page(LoginPage.class);

--- a/tests/utils/src/main/java/io/hawt/tests/utils/pageobjects/fragments/camel/CamelTree.java
+++ b/tests/utils/src/main/java/io/hawt/tests/utils/pageobjects/fragments/camel/CamelTree.java
@@ -18,7 +18,7 @@ public class CamelTree {
      * @return the given page object class
      */
     public <P> P expandSpecificFolder(Class<P> pageObjectClass, String folderPartialId) {
-        $("[id$='" + folderPartialId + "']").$("[class$='node-toggle']").shouldBe(interactable).click();
+        $("[id*='" + folderPartialId + "']").$("[class$='node-toggle']").shouldBe(interactable).click();
         return page(pageObjectClass);
     }
 
@@ -28,7 +28,7 @@ public class CamelTree {
      * @param itemPartialId of the item to be selected
      */
     public void selectSpecificItem(String itemPartialId) {
-        $("[id$='" + itemPartialId + "']").$("[class$='node-text']").shouldBe(interactable).click();
+        $("[id*='" + itemPartialId + "']").$("[class$='node-text']").shouldBe(interactable).click();
     }
 
     /**

--- a/tests/utils/src/main/java/io/hawt/tests/utils/pageobjects/fragments/menu/Menu.java
+++ b/tests/utils/src/main/java/io/hawt/tests/utils/pageobjects/fragments/menu/Menu.java
@@ -4,9 +4,11 @@ import static com.codeborne.selenide.Condition.attribute;
 import static com.codeborne.selenide.Condition.focused;
 import static com.codeborne.selenide.Condition.interactable;
 import static com.codeborne.selenide.Condition.not;
+import static com.codeborne.selenide.Selectors.byClassName;
 import static com.codeborne.selenide.Selectors.byLinkText;
 import static com.codeborne.selenide.Selenide.$;
 
+import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.SelenideElement;
 
 /**
@@ -21,10 +23,17 @@ public class Menu {
      */
     public void navigateTo(String navItem) {
         final SelenideElement item = $(byLinkText(navItem));
+        final SelenideElement emptyStateContent = $(byClassName("pf-c-empty-state__content"));
 
         toggleLeftSideBarIfCollapsed();
 
-        item.shouldBe(interactable).click();
+        item.click();
+
+        // Sometimes Selenide is faster than Hawtio and content is loaded properly
+        if (emptyStateContent.exists()) {
+            Selenide.refresh();
+            item.click();
+        }
 
         toggleLeftSideBarIfOverlaysCamelTree();
     }


### PR DESCRIPTION
In this PR:

- Test frameworks version updates
- Log out action fix
- Camel tree id-s stabilization
- Added one check as at some point Hawtio is slower than Selenide and sometimes the content is not loaded properly

The github checks will fail (usually, 3-4 failing tests scenarios per runtime) because of https://github.com/hawtio/hawtio-next/issues/318