### PR TITLE
Add redirect to hawtio/

### DIFF
--- a/platforms/springboot/src/main/java/io/hawt/springboot/HawtioEndpoint.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/HawtioEndpoint.java
@@ -11,6 +11,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponents;
 
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * Spring Boot endpoint to expose Hawtio.
  */
@@ -37,8 +39,13 @@ public class HawtioEndpoint implements WebMvcConfigurer {
     @RequestMapping(
         value = {"", "{path:^(?:(?!\\bjolokia\\b|auth|css|fonts|img|js|user|oauth|static|\\.).)*$}/**"},
         produces = MediaType.TEXT_HTML_VALUE)
-    public String forwardHawtioRequestToIndexHtml() {
+    public String forwardHawtioRequestToIndexHtml(HttpServletRequest request) {
         final String path = endpointPath.resolve("hawtio");
+
+        if (request.getRequestURI().equals(path)) {
+            return "redirect:" + path + "/";
+        }
+
         final UriComponents uriComponents = ServletUriComponentsBuilder.fromPath(path)
             .path("/index.html")
             .build();

--- a/platforms/springboot/src/test/java/io/hawt/springboot/HawtioEndpointTest.java
+++ b/platforms/springboot/src/test/java/io/hawt/springboot/HawtioEndpointTest.java
@@ -3,23 +3,37 @@ package io.hawt.springboot;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import javax.servlet.http.HttpServletRequest;
+
 import static org.junit.Assert.assertEquals;
 
 public class HawtioEndpointTest {
 
     private EndpointPathResolver resolver;
     private HawtioEndpoint hawtioEndpoint;
+    private HttpServletRequest httpServletRequest;
 
     @Before
     public void setUp() {
         resolver = Mockito.mock(EndpointPathResolver.class);
         hawtioEndpoint = new HawtioEndpoint(resolver);
+        httpServletRequest = Mockito.mock(HttpServletRequest.class);
     }
 
     @Test
     public void testForwardHawtioRequestToIndexHtml() {
         Mockito.when(resolver.resolve("hawtio")).thenReturn("/actuator/hawtio");
-        String result = hawtioEndpoint.forwardHawtioRequestToIndexHtml();
+        Mockito.when(httpServletRequest.getRequestURI()).thenReturn("/actuator/hawtio/");
+        String result = hawtioEndpoint.forwardHawtioRequestToIndexHtml(httpServletRequest);
         assertEquals("forward:/actuator/hawtio/index.html", result);
+    }
+
+    @Test
+    public void testRedirectHawtioInvalidRequest() {
+        Mockito.when(resolver.resolve("hawtio")).thenReturn("/actuator/hawtio");
+        Mockito.when(httpServletRequest.getRequestURI()).thenReturn("/actuator/hawtio");
+        String result = hawtioEndpoint.forwardHawtioRequestToIndexHtml(httpServletRequest);
+        assertEquals("redirect:/actuator/hawtio/", result);
     }
 }


### PR DESCRIPTION
This PR fixes the issue https://github.com/hawtio/hawtio/issues/2855 and applies same behavior as quarkus app (redirect in case of missing / in case of `actuator/hawtio`). Though I am not sure if there is another (better) way to achieve the same result.