### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-server to 12.0.0.beta0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <jackson-version>2.14.1</jackson-version>
     <jackson-version-range>[2.8,3)</jackson-version-range>
     <!-- <jetty-version>10.0.14</jetty-version> -->
-    <jetty-version>9.4.50.v20221201</jetty-version>
+    <jetty-version>12.0.0.beta0</jetty-version>
     <jetty-plugin-version>${jetty-version}</jetty-plugin-version>
     <jolokia-version>1.7.2</jolokia-version>
     <junit-version>4.13.2</junit-version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-server 9.4.50.v20221201
- [CVE-2023-26049](https://www.oscs1024.com/hd/CVE-2023-26049)


### What did I do？
Upgrade org.eclipse.jetty:jetty-server from 9.4.50.v20221201 to 12.0.0.beta0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS