### PR TITLE
Jetty 10 Upgrade for 2.x

### DIFF
--- a/examples/springboot-authentication-jar/pom.xml
+++ b/examples/springboot-authentication-jar/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <!-- Jetty version referred from the spring-boot-dependencies project -->
-    <jetty.version>9.4.11.v20180605</jetty.version>
+    <jetty.version>10.0.15</jetty.version>
   </properties>
 
   <dependencyManagement>
@@ -58,6 +58,11 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-jaas</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-security</artifactId>
       <version>${jetty.version}</version>
     </dependency>
     <dependency>

--- a/examples/springboot-authentication/pom.xml
+++ b/examples/springboot-authentication/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <!-- Jetty version referred from the spring-boot-dependencies project -->
-    <jetty.version>9.4.11.v20180605</jetty.version>
+    <jetty.version>10.0.15</jetty.version>
   </properties>
 
   <dependencyManagement>
@@ -58,6 +58,11 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-jaas</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-security</artifactId>
       <version>${jetty.version}</version>
     </dependency>
     <dependency>

--- a/examples/springboot-authentication/src/main/java/io/hawt/example/spring/boot/PropertyFileLoginModule.java
+++ b/examples/springboot-authentication/src/main/java/io/hawt/example/spring/boot/PropertyFileLoginModule.java
@@ -1,10 +1,17 @@
 package io.hawt.example.spring.boot;
 
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+
 import org.eclipse.jetty.jaas.spi.AbstractLoginModule;
-import org.eclipse.jetty.jaas.spi.UserInfo;
 import org.eclipse.jetty.security.PropertyUserStore;
-import org.eclipse.jetty.server.UserIdentity;
-import org.eclipse.jetty.util.security.Credential;
+import org.eclipse.jetty.security.RolePrincipal;
+import org.eclipse.jetty.security.UserPrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,27 +85,38 @@ public class PropertyFileLoginModule extends AbstractLoginModule {
     }
 
     @Override
-    public UserInfo getUserInfo(final String userName) {
+    public JAASUser getUser(String userName) throws Exception {
         final PropertyUserStore propertyUserStore = PROPERTY_USERSTORES.get(filename);
         if (propertyUserStore == null) {
             throw new IllegalStateException("PropertyUserStore should never be null here!");
         }
 
         LOG.trace("Checking PropertyUserStore " + filename + " for " + userName);
-        final UserIdentity userIdentity = propertyUserStore.getUserIdentity(userName);
-        if (userIdentity == null) {
+        final UserPrincipal userPrincipal = propertyUserStore.getUserPrincipal(userName);
+        final List<RolePrincipal> rolePrincipals = propertyUserStore.getRolePrincipals(userName);
+
+        if (userPrincipal == null || rolePrincipals == null) {
             return null;
         }
 
-        final Set<Principal> principals = userIdentity.getSubject().getPrincipals();
-        final List<String> roles = new ArrayList<>();
-        for (final Principal principal : principals) {
-            roles.add(principal.getName());
+        final List<String> roles = rolePrincipals.stream().map(RolePrincipal::getName).collect(Collectors.toList());
+
+        LOG.trace("Found: " + userName + " in PropertyUserStore " + filename);
+        return new HawtioJAASUser(userPrincipal, roles);
+    }
+
+    class HawtioJAASUser extends JAASUser {
+        List<String> roles;
+
+        public HawtioJAASUser(UserPrincipal userPrincipal, List<String> roles) {
+            super(userPrincipal);
+            this.roles = roles;
         }
 
-        final Credential credential = (Credential) userIdentity.getSubject().getPrivateCredentials().iterator().next();
-        LOG.trace("Found: " + userName + " in PropertyUserStore " + filename);
-        return new UserInfo(userName, credential, roles);
+        @Override
+        public List<String> doFetchRoles() throws Exception {
+            return roles;
+        }
     }
 
     @Override

--- a/hawtio-embedded/pom.xml
+++ b/hawtio-embedded/pom.xml
@@ -22,6 +22,11 @@
       <artifactId>jetty-server</artifactId>
       <version>${jetty-version}</version>
     </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>${servlet-api-version}</version>
+    </dependency>
 
     <!-- logging -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <httpclient-version>4.5.14</httpclient-version>
     <jackson-version>2.14.1</jackson-version>
     <jackson-version-range>[2.8,3)</jackson-version-range>
-    <jetty-version>9.4.51.v20230217</jetty-version>
+    <jetty-version>10.0.15</jetty-version>
     <jetty-plugin-version>${jetty-version}</jetty-plugin-version>
     <jolokia-version>1.7.2</jolokia-version>
     <junit-version>4.13.2</junit-version>

--- a/tests/springboot/pom.xml
+++ b/tests/springboot/pom.xml
@@ -88,6 +88,11 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-security</artifactId>
+      <version>${jetty-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http</artifactId>
     </dependency>
 

--- a/tests/springboot/src/main/java/io/hawt/tests/spring/boot/PropertyFileLoginModule.java
+++ b/tests/springboot/src/main/java/io/hawt/tests/spring/boot/PropertyFileLoginModule.java
@@ -1,10 +1,9 @@
 package io.hawt.tests.spring.boot;
 
 import org.eclipse.jetty.jaas.spi.AbstractLoginModule;
-import org.eclipse.jetty.jaas.spi.UserInfo;
 import org.eclipse.jetty.security.PropertyUserStore;
-import org.eclipse.jetty.server.UserIdentity;
-import org.eclipse.jetty.util.security.Credential;
+import org.eclipse.jetty.security.RolePrincipal;
+import org.eclipse.jetty.security.UserPrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,12 +11,10 @@ import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.login.LoginException;
 
-import java.security.Principal;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 public class PropertyFileLoginModule extends AbstractLoginModule {
     public static final String DEFAULT_FILENAME = "realm.properties";
@@ -75,27 +72,38 @@ public class PropertyFileLoginModule extends AbstractLoginModule {
     }
 
     @Override
-    public UserInfo getUserInfo(final String userName) {
+    public JAASUser getUser(String userName) throws Exception {
         final PropertyUserStore propertyUserStore = PROPERTY_USERSTORES.get(filename);
         if (propertyUserStore == null) {
             throw new IllegalStateException("PropertyUserStore should never be null here!");
         }
 
         LOG.trace("Checking PropertyUserStore " + filename + " for " + userName);
-        final UserIdentity userIdentity = propertyUserStore.getUserIdentity(userName);
-        if (userIdentity == null) {
+        final UserPrincipal userPrincipal = propertyUserStore.getUserPrincipal(userName);
+        final List<RolePrincipal> rolePrincipals = propertyUserStore.getRolePrincipals(userName);
+
+        if (userPrincipal == null || rolePrincipals == null) {
             return null;
         }
 
-        final Set<Principal> principals = userIdentity.getSubject().getPrincipals();
-        final List<String> roles = new ArrayList<>();
-        for (final Principal principal : principals) {
-            roles.add(principal.getName());
+        final List<String> roles = rolePrincipals.stream().map(RolePrincipal::getName).collect(Collectors.toList());
+
+        LOG.trace("Found: " + userName + " in PropertyUserStore " + filename);
+        return new HawtioJAASUser(userPrincipal, roles);
+    }
+
+    class HawtioJAASUser extends JAASUser {
+        List<String> roles;
+
+        public HawtioJAASUser(UserPrincipal userPrincipal, List<String> roles) {
+            super(userPrincipal);
+            this.roles = roles;
         }
 
-        final Credential credential = (Credential) userIdentity.getSubject().getPrivateCredentials().iterator().next();
-        LOG.trace("Found: " + userName + " in PropertyUserStore " + filename);
-        return new UserInfo(userName, credential, roles);
+        @Override
+        public List<String> doFetchRoles() throws Exception {
+            return roles;
+        }
     }
 
     @Override

--- a/tooling/hawtio-maven-plugin/pom.xml
+++ b/tooling/hawtio-maven-plugin/pom.xml
@@ -96,4 +96,25 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.6.0</version>
+        <configuration>
+          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+        </configuration>
+        <executions>
+          <execution>
+            <id>mojo-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
In addition to the cherry-pick from 3.x branch, I had to add the following:

- Explicitly set `maven-plugin-plugin` version because it was clashing with jetty 10
- Add `javax.servlet-api` to hawtio-embedded, given that is not provided by jetty 10 (I wonder why though)