### PR TITLE
[E2E Tests] New Camel Contexts Operations and Chart test scenarios

### DIFF
--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/common/CamelChart.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/common/CamelChart.java
@@ -1,0 +1,121 @@
+package io.hawt.tests.features.pageobjects.fragments.camel.tabs.common;
+
+import static com.codeborne.selenide.CollectionCondition.sizeGreaterThan;
+import static com.codeborne.selenide.Condition.enabled;
+import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.not;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selectors.byXpath;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.$$;
+
+import org.junit.jupiter.api.Assertions;
+
+import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.SelenideElement;
+
+import io.hawt.tests.features.pageobjects.pages.camel.CamelPage;
+
+/**
+ * Represents Chart Tab page in Camel.
+ */
+public class CamelChart extends CamelPage {
+    /**
+     * Click on edit button.
+     *
+     * @return camel chart
+     */
+    public CamelChart edit() {
+        clickButton("Edit watches");
+        return this;
+    }
+
+    /**
+     * Close Edit Watches mode.
+     *
+     * @return camel chart
+     */
+    public CamelChart closeEdit() {
+        clickButton("Close");
+        return this;
+    }
+
+    /**
+     * Unwatch all Camel Attributes.
+     */
+    public void unwatchAll() {
+        $(byXpath("//div[contains(@class, 'pf-m-available')]//span[text()='SampleCamel']/preceding-sibling::span/input")).shouldBe(enabled).click();
+        $(byXpath("//button[@aria-label='Add selected']")).shouldBe(enabled).click();
+    }
+
+    /**
+     * Watch a specific Camel Attribute.
+     *
+     * @param attribute to be watched
+     */
+    public void watch(String attribute) {
+        $(byXpath("//div[contains(@class, 'pf-m-chosen')]//span[@class='pf-c-dual-list-selector__item-toggle-icon']")).shouldBe(enabled).click();
+        $(byXpath("//span[text()='" + attribute + "']/preceding-sibling::span/input")).shouldBe(enabled).click();
+        $(byXpath("//button[@aria-label='Remove selected']")).shouldBe(enabled).click();
+    }
+
+    /**
+     * Assert that the name of specific attribute is displayed.
+     *
+     * @param attributeName of specific attribute to be displayed
+     * @return camel chart
+     */
+    public CamelChart checkSpecificAttributeIsDisplayed(String attributeName) {
+        getTitles().findBy(text(attributeName)).shouldBe(visible);
+        return this;
+    }
+
+    /**
+     * Assert that the name of specific attribute is not displayed.
+     *
+     * @param attributeName of specific attribute not to be displayed
+     */
+    public void checkSpecificAttributeIsNotDisplayed(String attributeName) {
+        getTitles().findBy(text(attributeName)).shouldNotBe(visible);
+    }
+
+    /**
+     * Assert that the values of tested attribute and from the chart are the same.
+     *
+     * @param attribute name of tested attribute
+     * @param value     string value of tested attribute
+     */
+    public void checkStringAttributeValue(String attribute, String value) {
+        Assertions.assertEquals(getValue(attribute), value);
+    }
+
+    /**
+     * Get the list of attributes from chart.
+     *
+     * @return list of attributes
+     */
+    private ElementsCollection getTitles() {
+        return $$(byXpath("//div[@class='pf-c-card__body']/div/div[1]")).shouldHave(sizeGreaterThan(0));
+    }
+
+    /**
+     * Get the value of specific attribute from chart.
+     *
+     * @param attribute name of tested attribute
+     * @return value of the tested attribute
+     */
+    private String getValue(String attribute) {
+        final SelenideElement chart = $(byXpath("//div[text()='" + attribute + "']/following-sibling::*[1]/descendant::*[local-name()='g'][1]/*[local-name()='path' and string-length(@d)!=0]"));
+        final SelenideElement chartBarValue = chart.$(byXpath("./ancestor::*[local-name()='g']/following-sibling::*[2]//*[local-name()='tspan']"));
+
+        chart.should(exist).hover();
+
+        if (chartBarValue.is(not(visible))) {
+            $(byXpath("//div[contains(text(),'SampleCamel TotalRoutes')]")).hover();
+            chart.should(exist).hover();
+        }
+
+        return chartBarValue.getText().substring(chartBarValue.getText().lastIndexOf(":") + 2);
+    }
+}

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/camel/CamelChartStepDefs.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/camel/CamelChartStepDefs.java
@@ -1,0 +1,39 @@
+package io.hawt.tests.features.stepdefinitions.camel;
+
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.hawt.tests.features.pageobjects.fragments.camel.tabs.common.CamelChart;
+
+public class CamelChartStepDefs {
+    private final CamelChart camelChart = new CamelChart();
+
+    @Then("^Camel Attribute \"([^\"]*)\" and its value \"([^\"]*)\" are displayed in Camel Chart$")
+    public void camelAttributeAndItsValueAreDisplayedInCamelChart(String attribute, String value) {
+        camelChart.checkSpecificAttributeIsDisplayed(attribute).checkStringAttributeValue(attribute, value);
+    }
+
+    @Then("^Camel Attribute \"([^\"]*)\" is not displayed in Camel Chart$")
+    public void camelAttributeIsNotDisplayedInCamelChart(String attribute) {
+        camelChart.checkSpecificAttributeIsNotDisplayed(attribute);
+    }
+
+    @When("^User switches to Edit watches mode of Camel Chart")
+    public void userSwitchesToEditWatchesModeOfCamelChart() {
+        camelChart.edit();
+    }
+
+    @When("^User unwatch all attributes$")
+    public void userUnwatchAllAttributes() {
+        camelChart.unwatchAll();
+    }
+
+    @When("^User watches \"([^\"]*)\" attribute$")
+    public void userWatchesAnAttribute(String attribute) {
+        camelChart.watch(attribute);
+    }
+
+    @When("^User closes Edit watches mode of Camel Chart$")
+    public void userClosesEditWatchesModeOfCamelChart() {
+        camelChart.closeEdit();
+    }
+}

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/contexts/camel_specific_context.feature
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/contexts/camel_specific_context.feature
@@ -14,12 +14,40 @@ Feature: Checking the functionality of a specific camel context page.
       | Value     | State     | Started     |
 
   @springBootAllTest @quarkusAllTest
-  Scenario: Check to execute operation of Specific Context
+  Scenario: Check to execute operation of Specific Context and returned result of String type
     Given User is on "Camel" page
     And User is on Camel "SampleCamel" context
     When User clicks on Camel "Operations" tab
     When User executes operation with name "getCamelId()"
     Then Result of "getCamelId()" operation is "SampleCamel"
+
+  @springBootAllTest @quarkusAllTest
+  Scenario: Check to execute operation of Specific Context and returned result of boolean type
+    Given User is on "Camel" page
+    And User is on Camel "SampleCamel" context
+    When User clicks on Camel "Operations" tab
+    When User executes operation with name "isLogMask()"
+    Then Result of "isLogMask()" operation is "false"
+
+  @springBootAllTest @quarkusAllTest
+  Scenario: Check to execute operation of Specific Context and returned result of Integer type
+    Given User is on "Camel" page
+    And User is on Camel "SampleCamel" context
+    When User clicks on Camel "Operations" tab
+    When User executes operation with name "getTotalRoutes()"
+    Then Result of "getTotalRoutes()" operation is "2"
+
+  @springBootAllTest @quarkusAllTest
+  Scenario: Check to view and edit chart of Specific Context
+    Given User is on "Camel" page
+    And User is on Camel "SampleCamel" context
+    When User clicks on Camel "Chart" tab
+    And User switches to Edit watches mode of Camel Chart
+    And User unwatch all attributes
+    And User watches "TotalRoutes" attribute
+    And User closes Edit watches mode of Camel Chart
+    Then Camel Attribute "SampleCamel TotalRoutes" and its value "2" are displayed in Camel Chart
+    And Camel Attribute "ExchangesFailed" is not displayed in Camel Chart
 
   @springBootAllTest @quarkusAllTest
   Scenario: Check the suspend action with Camel Specific Context.


### PR DESCRIPTION
### In this PR:

New test scenarios for Camel Context covering:
- Camel Chart
  - View Chart
  - Edit Chart

- Camel Operatios
  - Execute the operation returning a result of `boolean` type
  - Execute the operation returning a result of `int` type