### PR TITLE
ci: Publish e2e docker images into quay.io

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -14,6 +14,9 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        java: ['11', '17']
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
@@ -22,25 +25,28 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: 11
+          java-version: ${{ matrix.java }}
           cache: "maven"
       - name: Install
         run: |
           mvn ${MVN_ARGS} install
-      - name: Build example image
+      - name: Build images
         run: |
           mvn ${MVN_ARGS} install -Dquarkus.container-image.build=true -pl examples/quarkus
+          mvn ${MVN_ARGS} install -DskipTests -Pe2e -Pdocker-testsuite -Ptests-docker -Dhawtio-container -Ddocker.buildArg.JAVA_VERSION=${{ matrix.java }} -pl :hawtio-test-suite,:hawtio-tests-quarkus,:hawtio-tests-springboot -am
       - name: Display images
         run: |
           docker images
-      - name: Get project version
-        run: |
-          project_version=$(mvn ${MVN_ARGS} help:evaluate -Dexpression=project.version | grep -v "^\[")
-          echo "project_version=${project_version}" >> "$GITHUB_ENV"
       - name: Push image to Quay.io
         env:
           USERNAME: ${{ secrets.QUAY_USERNAME }}
           PASSWORD: ${{ secrets.QUAY_PASSWORD }}
         run: |
           docker login -u $USERNAME -p $PASSWORD quay.io
-          docker push quay.io/hawtio/hawtio-example-quarkus:${{ env.project_version }}
+          docker tag hawtio-test-suite:${{ matrix.java }} quay.io/hawtio/hawtio-test-suite:${{ github.ref_name }}-${{ matrix.java }}
+          docker tag hawtio-quarkus-app:${{ matrix.java }} quay.io/hawtio/hawtio-quarkus-test-app:${{ github.ref_name }}-${{ matrix.java }}
+          docker tag hawtio-springboot-app:${{ matrix.java }} quay.io/hawtio/hawtio-springboot-test-app:${{ github.ref_name }}-${{ matrix.java }}
+          for image in $(docker images --filter=reference='quay.io/hawtio/*' --format='{{.Repository}}:{{.Tag}}')
+          do
+            docker push $image
+          done

--- a/tests/hawtio-test-suite/pom.xml
+++ b/tests/hawtio-test-suite/pom.xml
@@ -46,7 +46,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/hooks/SkipTestsHook.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/hooks/SkipTestsHook.java
@@ -1,0 +1,14 @@
+package io.hawt.tests.features.hooks;
+
+import org.junit.jupiter.api.Assumptions;
+
+import io.cucumber.java.Before;
+
+public class SkipTestsHook {
+
+    @Before("@notHawtioNext")
+    public void skipHawtioNextTests() {
+        Assumptions.assumeTrue(System.getProperty("hawtio-next-ci") == null);
+    }
+
+}

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/pages/ConnectPage.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/pages/ConnectPage.java
@@ -2,6 +2,7 @@ package io.hawt.tests.features.pageobjects.pages;
 
 import static com.codeborne.selenide.Selenide.$;
 
+import org.awaitility.Awaitility;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
@@ -10,8 +11,10 @@ import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.WebDriverRunner;
 
 import java.net.URL;
+import java.time.Duration;
 
 import io.hawt.tests.features.config.TestConfiguration;
+import io.hawt.tests.features.setup.LoginLogout;
 
 public class ConnectPage extends HawtioPage {
 
@@ -58,7 +61,11 @@ public class ConnectPage extends HawtioPage {
         }
 
         Selenide.open(url, LoginPage.class).login(username, password);
-        Selenide.open(prevUrl);
+        Awaitility.waitAtMost(Duration.ofSeconds(5)).pollInSameThread()
+            .untilAsserted(() -> {
+                Selenide.open(prevUrl);
+                LoginLogout.hawtioIsLoaded();
+            });
 
         $(CONNECTION_LIST).$(connectionSelector).click();
         Selenide.Wait().until(ExpectedConditions.numberOfWindowsToBe(2));

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/panel/about/about_modal_window.feature
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/panel/about/about_modal_window.feature
@@ -1,3 +1,4 @@
+@notHawtioNext
 Feature: Check whether all data is presented and displayed correctly in About modal window.
 
   @springBootSmokeTest @springBootAllTest

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/plugin/plugin.feature
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/plugin/plugin.feature
@@ -1,4 +1,4 @@
-@springBootSmokeTest @springBootAllTest
+@springBootSmokeTest @springBootAllTest @notHawtioNext
 # @quarkusSmokeTest @quarkusAllTest - disabled due to https://github.com/hawtio/hawtio-next/issues/348
 Feature: Checking the functionality of Plugin page.
 


### PR DESCRIPTION
Builds test images on push and pushes them to Quay to be reused in hawtio-next.

Add tags to skip tests that require configuration that is not done in hawtio-next tests.
Related to https://github.com/hawtio/hawtio-next/pull/457