### PR TITLE
Bump javax servlet and karaf version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <jetty-plugin-version>${jetty-version}</jetty-plugin-version>
     <jolokia-version>1.7.2</jolokia-version>
     <junit-version>4.13.2</junit-version>
-    <karaf-version>4.3.4</karaf-version>
+    <karaf-version>4.4.3</karaf-version>
     <karaf-version-range>[4.0,5)</karaf-version-range>
     <keycloak-version>11.0.2</keycloak-version>
     <log4j-version>1.2.17</log4j-version>
@@ -89,7 +89,7 @@
     <mockito-core-version>4.3.1</mockito-core-version>
     <org-json-version>20230227</org-json-version>
     <osgi-version>5.0.0</osgi-version>
-    <servlet-api-version>3.1.0</servlet-api-version>
+    <servlet-api-version>4.0.1</servlet-api-version>
     <!-- use slf4j-api 1.6.x to be easy compatible with older Karaf/Camel releases -->
     <slf4j-api-version>1.6.6</slf4j-api-version>
     <slf4j-version>1.7.26</slf4j-version>


### PR DESCRIPTION
jetty 10 need javax.servlet 4.0.1, and the karaf version we had was too old for javax.servlet 4.0.1.