### PR TITLE
Upgrade to jetty12.0.0beta3 and spring-boot 3 

### DIFF
--- a/deploy/hawtio-base/pom.xml
+++ b/deploy/hawtio-base/pom.xml
@@ -57,36 +57,6 @@
           </httpConnector>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.tomcat.maven</groupId>
-        <artifactId>tomcat7-maven-plugin</artifactId>
-        <version>2.0</version>
-        <configuration>
-          <port>9090</port>
-          <path>${context}</path>
-          <systemProperties>
-          </systemProperties>
-          <useTestClasspath>false</useTestClasspath>
-          <!--
-                    <warSourceDirectory>${project.build.directory}/${project.name}-${project.version}</warSourceDirectory>
-          -->
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.tomcat.maven</groupId>
-        <artifactId>tomcat6-maven-plugin</artifactId>
-        <version>2.0</version>
-        <configuration>
-          <port>9090</port>
-          <path>${context}</path>
-          <systemProperties>
-          </systemProperties>
-          <useTestClasspath>false</useTestClasspath>
-          <!--
-                    <warSourceDirectory>${project.build.directory}/${project.name}-${project.version}</warSourceDirectory>
-          -->
-        </configuration>
-      </plugin>
 
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>

--- a/deploy/hawtio-base/src/main/webapp/WEB-INF/web.xml
+++ b/deploy/hawtio-base/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-         version="3.0">
+         xsi:schemaLocation = "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
 
   <description>hawtio</description>
   <display-name>hawtio</display-name>

--- a/deploy/hawtio-embedded/pom.xml
+++ b/deploy/hawtio-embedded/pom.xml
@@ -24,8 +24,8 @@
       <type>war</type>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-webapp</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-webapp</artifactId>
       <version>${jetty-version}</version>
     </dependency>
     <dependency>

--- a/deploy/hawtio-embedded/src/main/java/io/hawt/embedded/Main.java
+++ b/deploy/hawtio-embedded/src/main/java/io/hawt/embedded/Main.java
@@ -17,6 +17,14 @@
  */
 package io.hawt.embedded;
 
+import org.eclipse.jetty.ee10.webapp.WebAppContext;
+import org.eclipse.jetty.server.*;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
 import java.awt.*;
 import java.io.File;
 import java.io.IOException;
@@ -25,20 +33,6 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
-
-import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.HttpConfiguration;
-import org.eclipse.jetty.server.HttpConnectionFactory;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.SslConnectionFactory;
-import org.eclipse.jetty.server.handler.HandlerCollection;
-
-import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.eclipse.jetty.webapp.WebAppContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import picocli.CommandLine;
 
 /**
  * A simple way to run hawtio embedded inside a JVM by booting up a Jetty server
@@ -138,7 +132,7 @@ public class Main implements Callable<Integer>  {
     public String run(boolean join) throws Exception {
         Server server = new Server(new InetSocketAddress(InetAddress.getByName(host), port));
 
-        HandlerCollection handlers = new HandlerCollection();
+        ContextHandlerCollection handlers = new ContextHandlerCollection();
         handlers.setServer(server);
         server.setHandler(handlers);
 
@@ -212,7 +206,9 @@ public class Main implements Callable<Integer>  {
         webapp.setParentLoaderPriority(true);
         webapp.setLogUrlOnStart(true);
         webapp.setInitParameter("scheme", scheme);
-        webapp.setExtraClasspath(extraClassPath);
+        if (extraClassPath!= null) {
+            webapp.setExtraClasspath(extraClassPath);
+        }
         return webapp;
     }
 
@@ -246,7 +242,7 @@ public class Main implements Callable<Integer>  {
         return scheme;
     }
 
-    protected void findThirdPartyPlugins(Logger log, HandlerCollection handlers, File tempDir) {
+    protected void findThirdPartyPlugins(Logger log, ContextHandlerCollection handlers, File tempDir) {
         File dir = new File(plugins);
         if (!dir.exists() || !dir.isDirectory()) {
             return;
@@ -263,7 +259,7 @@ public class Main implements Callable<Integer>  {
             war -> deployPlugin(war, log, handlers, tempDir));
     }
 
-    private void deployPlugin(File war, Logger log, HandlerCollection handlers, File tempDir) {
+    private void deployPlugin(File war, Logger log, ContextHandlerCollection handlers, File tempDir) {
         String contextPath = resolveContextPath(war);
 
         WebAppContext plugin = new WebAppContext();

--- a/deploy/hawtio-embedded/src/main/java/io/hawt/embedded/Main.java
+++ b/deploy/hawtio-embedded/src/main/java/io/hawt/embedded/Main.java
@@ -17,14 +17,6 @@
  */
 package io.hawt.embedded;
 
-import org.eclipse.jetty.ee10.webapp.WebAppContext;
-import org.eclipse.jetty.server.*;
-import org.eclipse.jetty.server.handler.ContextHandlerCollection;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import picocli.CommandLine;
-
 import java.awt.*;
 import java.io.File;
 import java.io.IOException;
@@ -34,11 +26,19 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 
+import org.eclipse.jetty.ee10.webapp.WebAppContext;
+import org.eclipse.jetty.server.*;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
 /**
  * A simple way to run hawtio embedded inside a JVM by booting up a Jetty server
  */
 @CommandLine.Command(mixinStandardHelpOptions = true, name = "hawtio", description = "Run Hawtio")
-public class Main implements Callable<Integer>  {
+public class Main implements Callable<Integer> {
     private static Logger log = LoggerFactory.getLogger(Main.class);
     private static CommandLine commandLine;
 
@@ -206,7 +206,7 @@ public class Main implements Callable<Integer>  {
         webapp.setParentLoaderPriority(true);
         webapp.setLogUrlOnStart(true);
         webapp.setInitParameter("scheme", scheme);
-        if (extraClassPath!= null) {
+        if (extraClassPath != null) {
             webapp.setExtraClasspath(extraClassPath);
         }
         return webapp;

--- a/hawtio-war/src/main/webapp/WEB-INF/web.xml
+++ b/hawtio-war/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation = "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
-         version="5.0">
+         xsi:schemaLocation = "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
 
   <description>hawtio</description>
   <display-name>hawtio</display-name>

--- a/hawtio-war/src/main/webapp/WEB-INF/web.xml
+++ b/hawtio-war/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-         version="3.0">
+         xsi:schemaLocation = "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+         version="5.0">
 
   <description>hawtio</description>
   <display-name>hawtio</display-name>

--- a/platforms/springboot/pom.xml
+++ b/platforms/springboot/pom.xml
@@ -11,7 +11,7 @@
 
   <artifactId>hawtio-springboot</artifactId>
   <name>${project.artifactId}</name>
-  <description>Hawtio :: Spring Boot 2.x starter</description>
+  <description>Hawtio :: Spring Boot 3.x starter</description>
 
   <dependencyManagement>
     <dependencies>
@@ -77,12 +77,6 @@
     </dependency>
 
     <!-- testing -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit-version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>

--- a/platforms/springboot/src/integration-test/java/io/hawt/springboot/HawtioSpringBootCustomManagementPortIT.java
+++ b/platforms/springboot/src/integration-test/java/io/hawt/springboot/HawtioSpringBootCustomManagementPortIT.java
@@ -13,9 +13,9 @@ public class HawtioSpringBootCustomManagementPortIT extends HawtioSpringBootTest
     }
 
     @Test
-    public void testCustomManagementBasePath() {
+    public void testCustomManagementContextPath() {
         TestProperties properties = TestProperties.builder()
-            .managementBasePath("/management-context-path")
+            .managemenBasePath("/management-context-path")
             .build();
         getContextRunner().withPropertyValues(properties.getProperties()).run((context) -> {
             assertHawtioEndpointPaths(context, properties, true);
@@ -23,9 +23,9 @@ public class HawtioSpringBootCustomManagementPortIT extends HawtioSpringBootTest
     }
 
     @Test
-    public void testCustomManagementBasePathAndManagementWebBasePath() {
+    public void testCustomManagementContextPathAndManagementBasePath() {
         TestProperties properties = TestProperties.builder()
-            .managementBasePath("/management-context-path")
+            .managemenBasePath("/management-context-path")
             .managementWebBasePath("/management-base-path")
             .build();
         getContextRunner().withPropertyValues(properties.getProperties()).run((context) ->
@@ -33,9 +33,9 @@ public class HawtioSpringBootCustomManagementPortIT extends HawtioSpringBootTest
     }
 
     @Test
-    public void testCustomManagementBasePathManagementWebBasePathAndJolokiaPath() {
+    public void testCustomManagementContextPathManagementBasePathAndJolokiaPath() {
         TestProperties properties = TestProperties.builder()
-            .managementBasePath("/management-context-path")
+            .managemenBasePath("/management-context-path")
             .managementWebBasePath("/management-base-path")
             .jolokiaPath("jmx/jolokia")
             .build();
@@ -44,9 +44,9 @@ public class HawtioSpringBootCustomManagementPortIT extends HawtioSpringBootTest
     }
 
     @Test
-    public void testCustomManagementBasePathManagementWebBasePathJolokiaPathAndHawtioPath() {
+    public void testCustomManagementContextPathManagementBasePathJolokiaPathAndHawtioPath() {
         TestProperties properties = TestProperties.builder()
-            .managementBasePath("/management-context-path")
+            .managemenBasePath("/management-context-path")
             .managementWebBasePath("/management-base-path")
             .jolokiaPath("jmx/jolokia")
             .hawtioPath("hawtio/console")
@@ -56,9 +56,9 @@ public class HawtioSpringBootCustomManagementPortIT extends HawtioSpringBootTest
     }
 
     @Test
-    public void testCustomManagementBasePathAndJolokiaPath() {
+    public void testCustomManagementContextPathAndJolokiaPath() {
         TestProperties properties = TestProperties.builder()
-            .managementBasePath("/management-context-path")
+            .managemenBasePath("/management-context-path")
             .jolokiaPath("jmx/jolokia")
             .build();
         getContextRunner().withPropertyValues(properties.getProperties()).run((context) ->
@@ -66,9 +66,9 @@ public class HawtioSpringBootCustomManagementPortIT extends HawtioSpringBootTest
     }
 
     @Test
-    public void testCustomManagementBasePathAndHawtioPath() {
+    public void testCustomManagementContextPathAndHawtioPath() {
         TestProperties properties = TestProperties.builder()
-            .managementBasePath("/management-context-path")
+            .managemenBasePath("/management-context-path")
             .hawtioPath("hawtio/console")
             .build();
         getContextRunner().withPropertyValues(properties.getProperties()).run((context) ->
@@ -76,9 +76,9 @@ public class HawtioSpringBootCustomManagementPortIT extends HawtioSpringBootTest
     }
 
     @Test
-    public void testCustomManagementBasePathJolokiaPathAndHawtioPath() {
+    public void testCustomManagementContextPathJolokiaPathAndHawtioPath() {
         TestProperties properties = TestProperties.builder()
-            .managementBasePath("/management-context-path")
+            .managemenBasePath("/management-context-path")
             .jolokiaPath("jmx/jolokia")
             .hawtioPath("hawtio/console")
             .build();
@@ -87,9 +87,9 @@ public class HawtioSpringBootCustomManagementPortIT extends HawtioSpringBootTest
     }
 
     @Test
-    public void testMultipleManagementBasePath() {
+    public void testMultipleManagementContextPath() {
         TestProperties properties = TestProperties.builder()
-            .managementBasePath("/management/context/path")
+            .managemenBasePath("/management/context/path")
             .build();
         getContextRunner().withPropertyValues(properties.getProperties()).run((context) ->
             assertHawtioEndpointPaths(context, properties, true));

--- a/platforms/springboot/src/integration-test/java/io/hawt/springboot/HawtioSpringBootCustomManagementPortIT.java
+++ b/platforms/springboot/src/integration-test/java/io/hawt/springboot/HawtioSpringBootCustomManagementPortIT.java
@@ -15,7 +15,7 @@ public class HawtioSpringBootCustomManagementPortIT extends HawtioSpringBootTest
     @Test
     public void testCustomManagementContextPath() {
         TestProperties properties = TestProperties.builder()
-            .managemenBasePath("/management-context-path")
+            .managementBasePath("/management-context-path")
             .build();
         getContextRunner().withPropertyValues(properties.getProperties()).run((context) -> {
             assertHawtioEndpointPaths(context, properties, true);
@@ -25,7 +25,7 @@ public class HawtioSpringBootCustomManagementPortIT extends HawtioSpringBootTest
     @Test
     public void testCustomManagementContextPathAndManagementBasePath() {
         TestProperties properties = TestProperties.builder()
-            .managemenBasePath("/management-context-path")
+            .managementBasePath("/management-context-path")
             .managementWebBasePath("/management-base-path")
             .build();
         getContextRunner().withPropertyValues(properties.getProperties()).run((context) ->
@@ -35,7 +35,7 @@ public class HawtioSpringBootCustomManagementPortIT extends HawtioSpringBootTest
     @Test
     public void testCustomManagementContextPathManagementBasePathAndJolokiaPath() {
         TestProperties properties = TestProperties.builder()
-            .managemenBasePath("/management-context-path")
+            .managementBasePath("/management-context-path")
             .managementWebBasePath("/management-base-path")
             .jolokiaPath("jmx/jolokia")
             .build();
@@ -46,7 +46,7 @@ public class HawtioSpringBootCustomManagementPortIT extends HawtioSpringBootTest
     @Test
     public void testCustomManagementContextPathManagementBasePathJolokiaPathAndHawtioPath() {
         TestProperties properties = TestProperties.builder()
-            .managemenBasePath("/management-context-path")
+            .managementBasePath("/management-context-path")
             .managementWebBasePath("/management-base-path")
             .jolokiaPath("jmx/jolokia")
             .hawtioPath("hawtio/console")
@@ -58,7 +58,7 @@ public class HawtioSpringBootCustomManagementPortIT extends HawtioSpringBootTest
     @Test
     public void testCustomManagementContextPathAndJolokiaPath() {
         TestProperties properties = TestProperties.builder()
-            .managemenBasePath("/management-context-path")
+            .managementBasePath("/management-context-path")
             .jolokiaPath("jmx/jolokia")
             .build();
         getContextRunner().withPropertyValues(properties.getProperties()).run((context) ->
@@ -68,7 +68,7 @@ public class HawtioSpringBootCustomManagementPortIT extends HawtioSpringBootTest
     @Test
     public void testCustomManagementContextPathAndHawtioPath() {
         TestProperties properties = TestProperties.builder()
-            .managemenBasePath("/management-context-path")
+            .managementBasePath("/management-context-path")
             .hawtioPath("hawtio/console")
             .build();
         getContextRunner().withPropertyValues(properties.getProperties()).run((context) ->
@@ -78,7 +78,7 @@ public class HawtioSpringBootCustomManagementPortIT extends HawtioSpringBootTest
     @Test
     public void testCustomManagementContextPathJolokiaPathAndHawtioPath() {
         TestProperties properties = TestProperties.builder()
-            .managemenBasePath("/management-context-path")
+            .managementBasePath("/management-context-path")
             .jolokiaPath("jmx/jolokia")
             .hawtioPath("hawtio/console")
             .build();
@@ -89,7 +89,7 @@ public class HawtioSpringBootCustomManagementPortIT extends HawtioSpringBootTest
     @Test
     public void testMultipleManagementContextPath() {
         TestProperties properties = TestProperties.builder()
-            .managemenBasePath("/management/context/path")
+            .managementBasePath("/management/context/path")
             .build();
         getContextRunner().withPropertyValues(properties.getProperties()).run((context) ->
             assertHawtioEndpointPaths(context, properties, true));

--- a/platforms/springboot/src/integration-test/java/io/hawt/springboot/HawtioSpringBootTestSupport.java
+++ b/platforms/springboot/src/integration-test/java/io/hawt/springboot/HawtioSpringBootTestSupport.java
@@ -224,7 +224,7 @@ public class HawtioSpringBootTestSupport {
     protected static class TestPropertiesBuilder {
         private String contextPath;
         private String servletPath;
-        private String managementBasePath;
+        private String managementContextPath;
         private String managementWebBasePath;
         private String jolokiaPath;
         private String hawtioPath;
@@ -244,8 +244,8 @@ public class HawtioSpringBootTestSupport {
             return this;
         }
 
-        public TestPropertiesBuilder managementBasePath(String managementBasePath) {
-            this.managementBasePath = managementBasePath;
+        public TestPropertiesBuilder managemenBasePath(String managementContextPath) {
+            this.managementContextPath = managementContextPath;
             return this;
         }
 
@@ -290,7 +290,7 @@ public class HawtioSpringBootTestSupport {
         }
 
         public TestProperties build() {
-            return new TestProperties(contextPath, servletPath, managementBasePath,
+            return new TestProperties(contextPath, servletPath, managementContextPath,
                 managementWebBasePath, jolokiaPath, hawtioPath, hawtioExposed,
                 jolokiaExposed, hawtioEnabled, jolokiaEnabled, authenticationEnabled);
         }

--- a/platforms/springboot/src/integration-test/java/io/hawt/springboot/HawtioSpringBootTestSupport.java
+++ b/platforms/springboot/src/integration-test/java/io/hawt/springboot/HawtioSpringBootTestSupport.java
@@ -10,7 +10,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.jolokia.JolokiaEndpointAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.web.servlet.ServletManagementContextAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -21,13 +20,14 @@ import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguratio
 import org.springframework.boot.test.context.assertj.AssertableWebApplicationContext;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext;
+import org.springframework.test.util.TestSocketUtils;
 import org.springframework.test.web.reactive.server.WebTestClient;
-import org.springframework.util.SocketUtils;
+
 
 public class HawtioSpringBootTestSupport {
 
-    public static final int SERVER_PORT = SocketUtils.findAvailableTcpPort();
-    public static final int MANAGEMENT_PORT = SocketUtils.findAvailableTcpPort(SERVER_PORT + 1);
+    public static final int SERVER_PORT =  TestSocketUtils.findAvailableTcpPort();
+    public static final int MANAGEMENT_PORT = TestSocketUtils.findAvailableTcpPort();
 
     protected WebApplicationContextRunner contextRunner;
     protected boolean isCustomManagementPortConfigured = false;
@@ -224,7 +224,7 @@ public class HawtioSpringBootTestSupport {
     protected static class TestPropertiesBuilder {
         private String contextPath;
         private String servletPath;
-        private String managementContextPath;
+        private String managementBasePath;
         private String managementWebBasePath;
         private String jolokiaPath;
         private String hawtioPath;
@@ -244,8 +244,8 @@ public class HawtioSpringBootTestSupport {
             return this;
         }
 
-        public TestPropertiesBuilder managemenBasePath(String managementContextPath) {
-            this.managementContextPath = managementContextPath;
+        public TestPropertiesBuilder managementBasePath(String managementBasePath) {
+            this.managementBasePath = managementBasePath;
             return this;
         }
 
@@ -290,7 +290,7 @@ public class HawtioSpringBootTestSupport {
         }
 
         public TestProperties build() {
-            return new TestProperties(contextPath, servletPath, managementContextPath,
+            return new TestProperties(contextPath, servletPath, managementBasePath,
                 managementWebBasePath, jolokiaPath, hawtioPath, hawtioExposed,
                 jolokiaExposed, hawtioEnabled, jolokiaEnabled, authenticationEnabled);
         }

--- a/platforms/springboot/src/main/java/io/hawt/springboot/HawtioEndpoint.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/HawtioEndpoint.java
@@ -1,17 +1,17 @@
 package io.hawt.springboot;
 
 import java.util.List;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpoint;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponents;
-
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * Spring Boot endpoint to expose Hawtio.
@@ -43,7 +43,7 @@ public class HawtioEndpoint implements WebMvcConfigurer {
         final String path = endpointPath.resolve("hawtio");
 
         if (request.getRequestURI().equals(path)) {
-            return "redirect:" + path + "/";
+            return "redirect:" + path + "/index.html";
         }
 
         final UriComponents uriComponents = ServletUriComponentsBuilder.fromPath(path)
@@ -84,4 +84,10 @@ public class HawtioEndpoint implements WebMvcConfigurer {
             .addResourceLocations("classpath:/hawtio-static/img/");
         // @formatter:on
     }
+
+    @Override
+    public void configurePathMatch(PathMatchConfigurer configurer) {
+        configurer.setUseTrailingSlashMatch(true);
+    }
 }
+

--- a/platforms/springboot/src/main/java/io/hawt/springboot/HawtioEndpointAutoConfiguration.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/HawtioEndpointAutoConfiguration.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -14,13 +15,12 @@ import org.springframework.boot.autoconfigure.web.servlet.DispatcherServletPath;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
 /**
  * Autoconfiguration for Hawtio on Spring Boot.
  */
-@Configuration
+@ManagementContextConfiguration
 @ConditionalOnWebApplication
 @PropertySource("classpath:/io/hawt/springboot/application.properties")
 @EnableConfigurationProperties

--- a/platforms/springboot/src/main/java/io/hawt/springboot/HawtioManagementConfiguration.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/HawtioManagementConfiguration.java
@@ -8,8 +8,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import javax.annotation.Nonnull;
-import javax.servlet.DispatcherType;
-import javax.servlet.http.HttpServletRequest;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.DispatcherType;
 
 import io.hawt.system.ConfigManager;
 import io.hawt.web.auth.AuthenticationConfiguration;
@@ -34,9 +35,6 @@ import io.hawt.web.filters.XFrameOptionsFilter;
 import io.hawt.web.filters.XXSSProtectionFilter;
 import io.hawt.web.proxy.ProxyServlet;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.autoconfigure.jolokia.JolokiaEndpoint;
-import org.springframework.boot.actuate.autoconfigure.jolokia.JolokiaEndpointAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -44,13 +42,14 @@ import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
 import org.springframework.web.servlet.mvc.AbstractUrlViewController;
 
 import static io.hawt.web.filters.BaseTagHrefFilter.PARAM_APPLICATION_CONTEXT_PATH;
 
-@ManagementContextConfiguration
+@Configuration
 @AutoConfigureAfter(JolokiaEndpointAutoConfiguration.class)
 @ConditionalOnBean(HawtioEndpoint.class)
 public class HawtioManagementConfiguration {

--- a/platforms/springboot/src/main/java/io/hawt/springboot/JolokiaEndpoint.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/JolokiaEndpoint.java
@@ -1,0 +1,29 @@
+package io.hawt.springboot;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.jolokia.http.AgentServlet;
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.web.EndpointServlet;
+import org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpoint;
+
+/**
+ * {@link Endpoint @Endpoint} to expose a Jolokia {@link AgentServlet}.
+ */
+@ServletEndpoint(id = "jolokia")
+public class JolokiaEndpoint implements Supplier<EndpointServlet> {
+
+    private final Map<String, String> initParameters;
+
+    public JolokiaEndpoint(Map<String, String> initParameters) {
+        this.initParameters = initParameters;
+    }
+
+    @Override
+    public EndpointServlet get() {
+        return new EndpointServlet(AgentServlet.class).withInitParameters(this.initParameters);
+    }
+
+}

--- a/platforms/springboot/src/main/java/io/hawt/springboot/JolokiaEndpointAutoConfiguration.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/JolokiaEndpointAutoConfiguration.java
@@ -1,0 +1,25 @@
+package io.hawt.springboot;
+
+import io.hawt.springboot.JolokiaEndpoint;
+import io.hawt.springboot.JolokiaProperties;
+import org.jolokia.http.AgentServlet;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@ConditionalOnClass(AgentServlet.class)
+@ConditionalOnAvailableEndpoint(endpoint = JolokiaEndpoint.class)
+@EnableConfigurationProperties(JolokiaProperties.class)
+public class JolokiaEndpointAutoConfiguration {
+
+    @Bean
+    public JolokiaEndpoint jolokiaEndpoint(JolokiaProperties properties) {
+        return new JolokiaEndpoint(properties.getConfig());
+    }
+
+}

--- a/platforms/springboot/src/main/java/io/hawt/springboot/JolokiaProperties.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/JolokiaProperties.java
@@ -1,0 +1,16 @@
+package io.hawt.springboot;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "management.endpoint.jolokia")
+public class JolokiaProperties {
+    private final Map<String, String> config = new HashMap<>();
+
+    public Map<String, String> getConfig() {
+        return this.config;
+    }
+
+}

--- a/platforms/springboot/src/main/java/io/hawt/springboot/SpringHawtioContextListener.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/SpringHawtioContextListener.java
@@ -2,7 +2,7 @@ package io.hawt.springboot;
 
 import java.util.Objects;
 
-import javax.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextEvent;
 
 import io.hawt.HawtioContextListener;
 import io.hawt.system.ConfigManager;

--- a/platforms/springboot/src/main/resources/META-INF/spring.factories
+++ b/platforms/springboot/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-io.hawt.springboot.HawtioEndpointAutoConfiguration,\
-io.hawt.springboot.HawtioLogAutoConfiguration
-
-org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration=\
-io.hawt.springboot.HawtioManagementConfiguration

--- a/platforms/springboot/src/main/resources/META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports
+++ b/platforms/springboot/src/main/resources/META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports
@@ -1,0 +1,4 @@
+io.hawt.springboot.JolokiaEndpointAutoConfiguration
+io.hawt.springboot.HawtioEndpointAutoConfiguration
+io.hawt.springboot.HawtioLogAutoConfiguration
+io.hawt.springboot.HawtioManagementConfiguration

--- a/platforms/springboot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/platforms/springboot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,4 @@
+io.hawt.springboot.JolokiaEndpointAutoConfiguration
+io.hawt.springboot.HawtioEndpointAutoConfiguration
+io.hawt.springboot.HawtioLogAutoConfiguration
+io.hawt.springboot.HawtioManagementConfiguration

--- a/platforms/springboot/src/test/java/io/hawt/springboot/HawtioEndpointTest.java
+++ b/platforms/springboot/src/test/java/io/hawt/springboot/HawtioEndpointTest.java
@@ -4,7 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import static org.junit.Assert.assertEquals;
 
@@ -33,7 +33,8 @@ public class HawtioEndpointTest {
     public void testRedirectHawtioInvalidRequest() {
         Mockito.when(resolver.resolve("hawtio")).thenReturn("/actuator/hawtio");
         Mockito.when(httpServletRequest.getRequestURI()).thenReturn("/actuator/hawtio");
+
         String result = hawtioEndpoint.forwardHawtioRequestToIndexHtml(httpServletRequest);
-        assertEquals("redirect:/actuator/hawtio/", result);
+        assertEquals("redirect:/actuator/hawtio/index.html", result);
     }
 }

--- a/platforms/springboot/src/test/java/io/hawt/springboot/SpringHawtioContextListenerTest.java
+++ b/platforms/springboot/src/test/java/io/hawt/springboot/SpringHawtioContextListenerTest.java
@@ -1,7 +1,7 @@
 package io.hawt.springboot;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletContextEvent;
 
 import org.junit.Test;
 import org.mockito.Mockito;

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
     <build-helper-maven-plugin-version>1.12</build-helper-maven-plugin-version>
 
     <!-- Spring versions -->
-    <spring-version>5.3.27</spring-version>
-    <spring-boot-version>2.7.12</spring-boot-version>
+    <spring-version>6.0.10</spring-version>
+    <spring-boot-version>3.1.2</spring-boot-version>
 
     <!-- Quarkus version -->
     <quarkus-version>2.16.6.Final</quarkus-version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
     <failIfNoTests>false</failIfNoTests>
     <jettyPort>8282</jettyPort>
     <context>/hawtio</context>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
 
     <webapp-dir>${project.artifactId}-${project.version}</webapp-dir>
     <webapp-outdir>${basedir}/target/${webapp-dir}</webapp-outdir>
@@ -75,8 +75,7 @@
     <httpclient-version>4.5.13</httpclient-version>
     <jackson-version>2.14.1</jackson-version>
     <jackson-version-range>[2.8,3)</jackson-version-range>
-    <!-- <jetty-version>10.0.14</jetty-version> -->
-    <jetty-version>11.0.5</jetty-version>
+    <jetty-version>12.0.0.beta3</jetty-version>
     <jetty-plugin-version>${jetty-version}</jetty-plugin-version>
     <jolokia-version>2.0.0-SNAPSHOT</jolokia-version>
     <junit-version>4.13.2</junit-version>


### PR DESCRIPTION
I've upgraded the version of sb to sb3. I'm still facing the problems with resolving index.html and other things.

1.  It looks like links in static files aren't properly regenerated (probably responsibility of  `ResourceUrlEncodingFilter`) when management.server.port is configured to the different port as the server.port. When management.server.port isn't configured hawtio application is properly resolved.

2. application is resolved only when  directly  index.html is requested. When `actuator/hawtio/` is requested then I'm getting 404. This probably can be fixed by manual redirect to index.html in HawtioEndpoint but I don't feel that's the best solution. Probably the ResourceHandlers has to be tweaked. 