### PR TITLE
Draft: ci(e2e) - workaround flaky E2E tests

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
     strategy:
       fail-fast: false
@@ -33,8 +33,6 @@ jobs:
     env:
       REPORT_DIR: results-${{matrix.runtime}}-${{matrix.java}}-${{matrix.browser}} 
     steps:
-      - name: Docker Setup QEMU
-        uses: docker/setup-qemu-action@v2.2.0
       - name: Download images
         uses: actions/cache/restore@v3
         with:
@@ -48,6 +46,7 @@ jobs:
       - name: ${{ matrix.runtime }} E2E test (Java ${{ matrix.java }})
         id: test
         run: |
+          docker version
           docker run --rm \
           -v /var/run/docker.sock:/var/run/docker.sock \
           -v $PWD/$REPORT_DIR:/hawtio-test-suite/tests/hawtio-test-suite/target \
@@ -79,7 +78,7 @@ jobs:
           path: |
             results/**/*
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -99,8 +98,6 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
-      - name: Docker Setup QEMU
-        uses: docker/setup-qemu-action@v2.2.0
       - name: Build
         run: |
           mvn --batch-mode --no-transfer-progress install -DskipTests -Pe2e -Pdocker-testsuite -Ptests-docker -Dhawtio-container -Ddocker.buildArg.JAVA_VERSION=${{ matrix.java }} -pl :hawtio-test-suite,:hawtio-tests-quarkus,:hawtio-tests-springboot -am
@@ -115,9 +112,13 @@ jobs:
         with:
           path: /tmp/images
           key: e2e-docker-images-${{ matrix.java }}-${{ github.run_id }}-${{ github.run_attempt }}
-
+      - name: Archive test artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: 'images-${{matrix.java}}'
+          path: '/tmp/images/*.tar'
   publish-results:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: test
     if: always()
     permissions:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -46,7 +46,6 @@ jobs:
       - name: ${{ matrix.runtime }} E2E test (Java ${{ matrix.java }})
         id: test
         run: |
-          docker version
           docker run --rm \
           -v /var/run/docker.sock:/var/run/docker.sock \
           -v $PWD/$REPORT_DIR:/hawtio-test-suite/tests/hawtio-test-suite/target \
@@ -112,11 +111,6 @@ jobs:
         with:
           path: /tmp/images
           key: e2e-docker-images-${{ matrix.java }}-${{ github.run_id }}-${{ github.run_attempt }}
-      - name: Archive test artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: 'images-${{matrix.java}}'
-          path: '/tmp/images/*.tar'
   publish-results:
     runs-on: ubuntu-22.04
     needs: test

--- a/tests/hawtio-test-suite/Dockerfile
+++ b/tests/hawtio-test-suite/Dockerfile
@@ -1,11 +1,12 @@
 ARG JAVA_VERSION=11
+ARG SELENIUM_VERSION=4.10
 
-FROM selenium/standalone-firefox:latest as firefoxImage
+FROM selenium/standalone-firefox:${SELENIUM_VERSION} as firefoxImage
 USER root
 RUN mkdir hawtio-test-suite
 WORKDIR hawtio-test-suite
 RUN export > env_init.sh
-FROM selenium/standalone-chrome:latest as chromeImage
+FROM selenium/standalone-chrome:${SELENIUM_VERSION} as chromeImage
 
 FROM maven:3-eclipse-temurin-${JAVA_VERSION}
 COPY --from=firefoxImage / /

--- a/tests/hawtio-test-suite/pom.xml
+++ b/tests/hawtio-test-suite/pom.xml
@@ -245,6 +245,7 @@
         <configuration>
           <skipTests>${skipTests}</skipTests>
           <test>${test-class}</test>
+          <rerunFailingTestsCount>2</rerunFailingTestsCount>
           <systemProperties>
             <io.hawt.test.runtime>${test-runtime}</io.hawt.test.runtime>
             <io.hawt.test.url.suffix>${hawtio.url}</io.hawt.test.url.suffix>

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/hooks/LoginLogoutHooks.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/hooks/LoginLogoutHooks.java
@@ -3,6 +3,7 @@ package io.hawt.tests.features.hooks;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.Assertions;
+import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.logging.LogType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,10 +32,14 @@ public class LoginLogoutHooks {
             LoginLogout.login(TestConfiguration.getAppUsername(), TestConfiguration.getAppPassword());
             init = true;
         } else {
-            if (Selenide.webdriver().driver().getWebDriver().getCurrentUrl().contains("login")) {
+            try {
+                if (Selenide.webdriver().driver().getWebDriver().getCurrentUrl().contains("login")) {
+                    LoginLogout.login(TestConfiguration.getAppUsername(), TestConfiguration.getAppPassword());
+                } else {
+                    Selenide.open(DeployAppHook.getBaseURL() + TestConfiguration.getUrlSuffix() + "/jmx");
+                }
+            } catch (NoSuchSessionException e) {
                 LoginLogout.login(TestConfiguration.getAppUsername(), TestConfiguration.getAppPassword());
-            } else {
-                Selenide.open(DeployAppHook.getBaseURL() + TestConfiguration.getUrlSuffix() + "/jmx");
             }
         }
         LoginLogout.hawtioIsLoaded();

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/WebDriver.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/WebDriver.java
@@ -1,10 +1,7 @@
 package io.hawt.tests.features.setup;
 
-import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.chrome.ChromeDriverService;
-import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.GeckoDriverService;
-import org.openqa.selenium.remote.DesiredCapabilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +24,9 @@ public class WebDriver {
         if (TestConfiguration.isRunningInContainer()) {
             setupDriverPaths();
             System.setProperty(GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY, "target/driver.log");
+            System.setProperty(GeckoDriverService.GECKO_DRIVER_LOG_LEVEL_PROPERTY, "INFO");
             System.setProperty(ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY, "target/driver.log");
+            System.setProperty(ChromeDriverService.CHROME_DRIVER_LOG_LEVEL_PROPERTY, "WARNING");
         }
         System.setProperty("hawtio.proxyWhitelist", "localhost, 127.0.0.1");
         Configuration.headless = TestConfiguration.browserHeadless();
@@ -44,9 +43,9 @@ public class WebDriver {
             System.setProperty("webdriver.firefox.driver", optFolder.resolve(path).toAbsolutePath().toString());
         });
         Path seleniumFolder = optFolder.resolve("selenium");
-        Arrays.stream(seleniumFolder.toFile().list()).filter(f -> f.startsWith("chromedriver")).findFirst()
-            .ifPresent(path -> {
-                System.setProperty("webdriver.chrome.driver", seleniumFolder.resolve(path).toAbsolutePath().toString());
+        Arrays.stream(seleniumFolder.toFile().listFiles((f, name) -> name.startsWith("chromedriver"))).filter(f -> f.isFile() && f.canExecute()).findFirst()
+            .ifPresent(file -> {
+                System.setProperty("webdriver.chrome.driver", file.getAbsolutePath());
             });
     }
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -89,6 +89,9 @@
                     <name>${image.name}:${java.vm.specification.version}</name>
                     <build>
                       <dockerFile>${basedir}/Dockerfile</dockerFile>
+                      <args>
+                        <SELENIUM_VERSION>${selenium-version}</SELENIUM_VERSION>
+                      </args>
                     </build>
                   </image>
                 </images>


### PR DESCRIPTION
Sometimes chrome just crashes in a docker container - no matter what I tried, seems like more people than me have the same issue... So I fixed the code to reopen the browser after the tab crashes and rerun the test if the test fails.
I sent some crash reports to the chromium team, but I'm not sure if there's much info to work with
Closes https://github.com/hawtio/hawtio-next/issues/478