### PR TITLE
[E2E Tests] Camel Endpoint messaging tests

### DIFF
--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/CamelTree.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/CamelTree.java
@@ -1,5 +1,6 @@
 package io.hawt.tests.features.pageobjects.fragments.camel;
 
+import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.interactable;
 import static com.codeborne.selenide.Selectors.byId;
 import static com.codeborne.selenide.Selenide.$;
@@ -18,7 +19,9 @@ public class CamelTree {
      * @return the given page object class
      */
     public <P> P expandSpecificFolder(Class<P> pageObjectClass, String folderPartialId) {
-        $("[id*='" + folderPartialId + "']").$("[class$='node-toggle']").shouldBe(interactable).click();
+        if (!$("[id*='" + folderPartialId + "']").has(cssClass("pf-m-expanded"))) {
+            $("[id*='" + folderPartialId + "']").$("[class$='node-toggle']").shouldBe(interactable).click();
+        }
         return page(pageObjectClass);
     }
 

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/endpoints/CamelBrowse.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/endpoints/CamelBrowse.java
@@ -1,0 +1,66 @@
+package io.hawt.tests.features.pageobjects.fragments.camel.tabs.endpoints;
+
+import static com.codeborne.selenide.Condition.enabled;
+import static com.codeborne.selenide.Condition.exactText;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selectors.byAttribute;
+import static com.codeborne.selenide.Selectors.byTagAndText;
+import static com.codeborne.selenide.Selectors.byTagName;
+import static com.codeborne.selenide.Selectors.byXpath;
+import static com.codeborne.selenide.Selenide.$;
+import io.hawt.tests.features.pageobjects.pages.camel.CamelPage;
+
+/**
+ * Represents Browse Tab page in Camel Endpoints.
+ */
+public class CamelBrowse extends CamelPage {
+    /**
+     * Checks that the message is visible in the list.
+     *
+     * @param message to be checked
+     */
+    public void browseMessage(String message) {
+        $(byTagAndText("td", message)).shouldBe(visible);
+    }
+
+    /**
+     * Select the message from the list.
+     *
+     * @param message to be selected
+     */
+    public void selectMessage(String message) {
+        $(byXpath("//td[text()='" + message + "']/preceding-sibling::td//input")).shouldBe(enabled).click();
+    }
+
+    /**
+     * Forward the selected message.
+     *
+     * @param endpointURI where the message is forwared
+     */
+    public void forwardSelectedMessage(String endpointURI) {
+        clickButton("Forward");
+        $(byXpath("//div[contains(@class, 'modal')]//input[@aria-label='Search input']")).shouldBe(enabled).click();
+        $(byTagAndText("p", endpointURI)).shouldBe(visible).click();
+        $(byXpath("//div[contains(@class, 'modal')]//button[text()='Forward']")).shouldBe(enabled).click();
+        successfulAlertMessage().closeAlertMessage();
+        $(byAttribute("aria-label", "Close")).shouldBe(visible).click();
+    }
+
+    /**
+     * Click on the message to open its details.
+     *
+     * @param message details to be shown
+     */
+    public void clickOnMessage(String message) {
+        $(byXpath("//td[text()='" + message + "']/preceding-sibling::td//button")).shouldBe(enabled).click();
+    }
+
+    /**
+     * Check that the message details are shown.
+     *
+     * @param message to be checked
+     */
+    public void detailsAreDisplayed(String message) {
+        $(byTagName("pre")).shouldHave(exactText(message));
+    }
+}

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/endpoints/CamelSend.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/endpoints/CamelSend.java
@@ -1,0 +1,56 @@
+package io.hawt.tests.features.pageobjects.fragments.camel.tabs.endpoints;
+
+import static com.codeborne.selenide.Condition.enabled;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selectors.byAttribute;
+import static com.codeborne.selenide.Selectors.byTagAndText;
+import static com.codeborne.selenide.Selectors.byXpath;
+import static com.codeborne.selenide.Selenide.$;
+import io.hawt.tests.features.pageobjects.pages.camel.CamelPage;
+
+
+/**
+ * Represents Send Tab page in Camel Endpoints.
+ */
+public class CamelSend extends CamelPage {
+
+    /**
+     * Add one header to the message.
+     *
+     * @param header      name to be added
+     * @param headerValue to be added
+     */
+    public void addOneHeader(String header, String headerValue) {
+        $(byTagAndText("button", "Add Headers")).shouldBe(enabled).click();
+        $(byAttribute("aria-label", "Search input")).shouldBe(enabled).click();
+        $(byTagAndText("p", header)).shouldBe(visible).click();
+        $(byAttribute("name", "value")).shouldBe(enabled).setValue(headerValue);
+    }
+
+    /**
+     * Add the message body and select its format.
+     *
+     * @param message body content
+     */
+    public void addMessageBody(String message) {
+        $(byXpath("//textarea")).sendKeys(message);
+    }
+
+    /**
+     * Set the message type.
+     *
+     * @param messageType whether plaintext, xml or json
+     */
+    public void setMessageType(String messageType) {
+        $(byAttribute("aria-label", "Options menu")).shouldBe(enabled).click();
+        $(byTagAndText("button", messageType)).shouldBe(visible).click();
+        clickButton("Format");
+    }
+
+    /**
+     * Send the message.
+     */
+    public void sendMessage() {
+        clickButton("Send");
+    }
+}

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/camel/endpoints/CamelEndpointsStepDefs.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/camel/endpoints/CamelEndpointsStepDefs.java
@@ -1,10 +1,16 @@
 package io.hawt.tests.features.stepdefinitions.camel.endpoints;
 
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import io.hawt.tests.features.pageobjects.fragments.camel.tabs.endpoints.CamelBrowse;
 import io.hawt.tests.features.pageobjects.fragments.camel.tabs.endpoints.CamelEndpoints;
+import io.hawt.tests.features.pageobjects.fragments.camel.tabs.endpoints.CamelSend;
 
 public class CamelEndpointsStepDefs {
+    private final CamelBrowse camelBrowse = new CamelBrowse();
     private final CamelEndpoints camelEndpoints = new CamelEndpoints();
+    private final CamelSend camelSend = new CamelSend();
 
     @When("^User adds Endpoint \"([^\"]*)\" from URI$")
     public void userAddsEndpointFromUri(String endpointUri) {
@@ -16,5 +22,50 @@ public class CamelEndpointsStepDefs {
     public void userAddsEndpointFromData(String endpoint, String component) {
         camelEndpoints.add()
             .fromData(endpoint, component);
+    }
+
+    @When("^User sets \"([^\"]*)\" header with value of \"([^\"]*)\"$")
+    public void userSetsHeaderWithValueOf(String header, String headerValue) {
+        camelSend.addOneHeader(header, headerValue);
+    }
+
+    @When("^User adds \"([^\"]*)\" message body$")
+    public void userSetsMessageAs(String message) {
+        camelSend.addMessageBody(message);
+    }
+
+    @When("^User sets \"([^\"]*)\" message type$")
+    public void userSetsMessageType(String messageType) {
+        camelSend.setMessageType(messageType);
+    }
+
+    @When("^User sends the message$")
+    public void userSendsMessageAs() {
+        camelSend.sendMessage();
+    }
+
+    @Then("^User can browse the message with \"([^\"]*)\" body$")
+    public void userCanBrowseMessageWithBody(String message) {
+        camelBrowse.browseMessage(message);
+    }
+
+    @When("^User selects the message with \"([^\"]*)\" body$")
+    public void userSelectsMessage(String message) {
+        camelBrowse.selectMessage(message);
+    }
+
+    @And("^User forwards the message to \"([^\"]*)\" URI$")
+    public void userForwardsMessageTo(String endpointURI) {
+        camelBrowse.forwardSelectedMessage(endpointURI);
+    }
+
+    @When("^User clicks on the message with \"([^\"]*)\" body$")
+    public void userClicksOnMessageWithBody(String message) {
+        camelBrowse.clickOnMessage(message);
+    }
+
+    @Then("^Details of the message with \"([^\"]*)\" body are displayed$")
+    public void detailsOfTheMessageWithBodAreDisplayed(String message) {
+        camelBrowse.detailsAreDisplayed(message);
     }
 }

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/endpoints/camel_specific_endpoint.feature
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/endpoints/camel_specific_endpoint.feature
@@ -28,3 +28,36 @@ Feature: Checking the functionality of a Camel Specific Endpoint page.
     And User clicks on Camel "Operations" tab
     When User executes operation with name "getCamelId()"
     Then Result of "getCamelId()" operation is "SampleCamel"
+
+  @springBootAllTest @quarkusAllTest
+  Scenario: Check sending a message
+    Given User is on "Camel" page
+    And User is on Camel "mock://bar" item of "endpoints" folder of "SampleCamel" context
+    And User clicks on Camel "Send" tab
+    When User sets "CamelFileName" header with value of "Test Name"
+    And User adds "Hello Test" message body
+    And User sets "plaintext" message type
+    And User sends the message
+    And Successful alert message is appeared and closed
+    Then User clicks on Camel "Browse" tab
+    And User can browse the message with "Hello Test" body
+
+  @springBootAllTest @quarkusAllTest
+  Scenario: Check forwarding the message
+    Given User is on "Camel" page
+    And User is on Camel "mock://bar" item of "endpoints" folder of "SampleCamel" context
+    And User clicks on Camel "Browse" tab
+    When User selects the message with "Hello Test" body
+    And User forwards the message to "mock://result" URI
+    Then User is on Camel "mock://result" item of "endpoints" folder of "SampleCamel" context
+    And User clicks on Camel "Browse" tab
+    And User can browse the message with "Hello Test" body
+
+  @springBootAllTest @quarkusAllTest
+  Scenario: Check details of the message
+    Given User is on "Camel" page
+    And User is on Camel "endpoints" folder of "SampleCamel" context
+    And User is on Camel "mock://result" item of "endpoints" folder of "SampleCamel" context
+    And User clicks on Camel "Browse" tab
+    When User clicks on the message with "Hello Test" body
+    Then Details of the message with "Hello Test" body are displayed


### PR DESCRIPTION
In this PR I added:
- Camel Endpoint messaging E2E tests (send, browse, forward, view)
- Fix a test method when expanding an item in the Camel tree (if already expanded - do not click again)