### PR TITLE
chore: update camel version in examples to 4.0.0  jetty to 12.0.1

### DIFF
--- a/examples/springboot-log4j2/pom.xml
+++ b/examples/springboot-log4j2/pom.xml
@@ -17,7 +17,7 @@
   <description>Hawtio :: Sample Spring Boot 3.x process with Log4J2</description>
 
   <properties>
-    <camel-version>4.0.0-M2</camel-version>
+    <camel-version>4.0.0</camel-version>
   </properties>
 
   <dependencyManagement>

--- a/examples/springboot/pom.xml
+++ b/examples/springboot/pom.xml
@@ -16,7 +16,7 @@
   <description>Hawtio :: Sample Spring Boot 3.x process</description>
 
   <properties>
-    <camel-version>4.0.0-M2</camel-version>
+    <camel-version>4.0.0</camel-version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <httpclient-version>4.5.13</httpclient-version>
     <jackson-version>2.14.1</jackson-version>
     <jackson-version-range>[2.8,3)</jackson-version-range>
-    <jetty-version>12.0.0.beta4</jetty-version>
+    <jetty-version>12.0.1</jetty-version>
     <jetty-plugin-version>${jetty-version}</jetty-plugin-version>
     <jolokia-version>2.0.0-SNAPSHOT</jolokia-version>
     <junit-version>4.13.2</junit-version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -16,7 +16,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <camel-version>3.21.0</camel-version>
+    <camel-version>4.0.0</camel-version>
     <http5-version>5.2.1</http5-version>
     <guava-version>32.0.0-jre</guava-version>
     <slf4j-version>2.0.7</slf4j-version>


### PR DESCRIPTION
Jetty 12 is finally released and so is camel 4.