### PR TITLE
[E2E Tests] Fix About dialog tests

### DIFF
--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/panel/about/AboutModalWindowStepDefs.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/panel/about/AboutModalWindowStepDefs.java
@@ -10,7 +10,7 @@ import io.cucumber.java.en.Then;
 public class AboutModalWindowStepDefs {
     @Then("^The \"([^\"]*)\" header is presented in About modal window$")
     public void aboutModalWindowHeaderIsPresented(String header) {
-        $("#pf-about-modal-title-0").shouldHave(exactText(header));
+        $("[id*='pf-about-modal-title']").shouldHave(exactText(header));
     }
 
     @And("^The \"([^\"]*)\" is presented in About modal window$")


### PR DESCRIPTION
Hi @tadayosi 
It seems the previous fix wasn't enough, I assume everytime the id if the title in the Aboud dialog has different digit suffix. So I have changed the selector. Hopefully, it will resolve the issue
Thanks