### PR TITLE
fix(system): apply new Jolokia 2.0.0 (snapshot version)

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '11', '17' ]
+        java: [ '17' ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/deploy/hawtio-base/pom.xml
+++ b/deploy/hawtio-base/pom.xml
@@ -42,9 +42,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-maven-plugin</artifactId>
-        <version>${jetty-version}</version>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-maven-plugin</artifactId>
         <configuration>
           <webAppSourceDirectory>${project.build.directory}/${project.name}</webAppSourceDirectory>
           <scanIntervalSeconds>1</scanIntervalSeconds>

--- a/deploy/hawtio-default/pom.xml
+++ b/deploy/hawtio-default/pom.xml
@@ -68,9 +68,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-maven-plugin</artifactId>
-        <version>${jetty-version}</version>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-maven-plugin</artifactId>
         <configuration>
           <webAppSourceDirectory>${project.build.directory}/${project.name}</webAppSourceDirectory>
           <scanIntervalSeconds>1</scanIntervalSeconds>

--- a/examples/springboot/src/main/java/io/hawt/example/spring/boot/SampleSpringBootService.java
+++ b/examples/springboot/src/main/java/io/hawt/example/spring/boot/SampleSpringBootService.java
@@ -4,17 +4,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.web.exchanges.HttpExchangeRepository;
 import org.springframework.boot.actuate.web.exchanges.InMemoryHttpExchangeRepository;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
-
-import java.util.Arrays;
 
 @SpringBootApplication
 public class SampleSpringBootService {
 
     public static void main(String[] args) {
-       ConfigurableApplicationContext context =  SpringApplication.run(SampleSpringBootService.class, args);
-       Arrays.stream(context.getBeanDefinitionNames()).forEach(System.out::println);
+        SpringApplication.run(SampleSpringBootService.class, args);
     }
 
     /**

--- a/examples/war-plugin/pom.xml
+++ b/examples/war-plugin/pom.xml
@@ -87,7 +87,6 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>${jetty-version}</version>
         <configuration>
           <deployMode>EMBED</deployMode>
           <scan>10</scan>

--- a/hawtio-system/pom.xml
+++ b/hawtio-system/pom.xml
@@ -22,9 +22,53 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Jolokia -->
     <dependency>
-      <groupId>org.jolokia</groupId>
-      <artifactId>jolokia-core-jakarta</artifactId>
+      <!-- <groupId>org.jolokia</groupId> -->
+      <groupId>com.github.jolokia.jolokia</groupId>
+      <artifactId>jolokia-server-core</artifactId>
+      <version>${jolokia-version}</version>
+    </dependency>
+    <dependency>
+      <!-- <groupId>org.jolokia</groupId> -->
+      <groupId>com.github.jolokia.jolokia</groupId>
+      <artifactId>jolokia-service-serializer</artifactId>
+      <version>${jolokia-version}</version>
+    </dependency>
+    <dependency>
+      <!-- <groupId>org.jolokia</groupId> -->
+      <groupId>com.github.jolokia.jolokia</groupId>
+      <artifactId>jolokia-service-jmx</artifactId>
+      <version>${jolokia-version}</version>
+    </dependency>
+    <dependency>
+      <!-- <groupId>org.jolokia</groupId> -->
+      <groupId>com.github.jolokia.jolokia</groupId>
+      <artifactId>jolokia-service-discovery</artifactId>
+      <version>${jolokia-version}</version>
+    </dependency>
+    <dependency>
+      <!-- <groupId>org.jolokia</groupId> -->
+      <groupId>com.github.jolokia.jolokia</groupId>
+      <artifactId>jolokia-service-history</artifactId>
+      <version>${jolokia-version}</version>
+    </dependency>
+    <dependency>
+      <!-- <groupId>org.jolokia</groupId> -->
+      <groupId>com.github.jolokia.jolokia</groupId>
+      <artifactId>jolokia-service-jsr160</artifactId>
+      <version>${jolokia-version}</version>
+    </dependency>
+    <dependency>
+      <!-- <groupId>org.jolokia</groupId> -->
+      <groupId>com.github.jolokia.jolokia</groupId>
+      <artifactId>jolokia-service-notif-pull</artifactId>
+      <version>${jolokia-version}</version>
+    </dependency>
+    <dependency>
+      <!-- <groupId>org.jolokia</groupId> -->
+      <groupId>com.github.jolokia.jolokia</groupId>
+      <artifactId>jolokia-service-notif-sse</artifactId>
       <version>${jolokia-version}</version>
     </dependency>
 

--- a/hawtio-system/src/main/java/io/hawt/system/RBACRestrictor.java
+++ b/hawtio-system/src/main/java/io/hawt/system/RBACRestrictor.java
@@ -16,18 +16,17 @@
 package io.hawt.system;
 
 import java.io.IOException;
-
 import javax.management.ObjectName;
 
-import org.jolokia.config.ConfigKey;
-import org.jolokia.config.Configuration;
-import org.jolokia.restrictor.AllowAllRestrictor;
-import org.jolokia.restrictor.DenyAllRestrictor;
-import org.jolokia.restrictor.Restrictor;
-import org.jolokia.restrictor.RestrictorFactory;
-import org.jolokia.util.HttpMethod;
-import org.jolokia.util.NetworkUtil;
-import org.jolokia.util.RequestType;
+import org.jolokia.server.core.config.ConfigKey;
+import org.jolokia.server.core.config.Configuration;
+import org.jolokia.server.core.restrictor.AllowAllRestrictor;
+import org.jolokia.server.core.restrictor.DenyAllRestrictor;
+import org.jolokia.server.core.restrictor.RestrictorFactory;
+import org.jolokia.server.core.service.api.Restrictor;
+import org.jolokia.server.core.util.HttpMethod;
+import org.jolokia.server.core.util.NetworkUtil;
+import org.jolokia.server.core.util.RequestType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +47,7 @@ public class RBACRestrictor implements Restrictor {
     }
 
     protected void initDelegate(Configuration config) {
-        String location = NetworkUtil.replaceExpression(config.get(ConfigKey.POLICY_LOCATION));
+        String location = NetworkUtil.replaceExpression(config.getConfig(ConfigKey.POLICY_LOCATION));
         try {
             this.delegate = RestrictorFactory.lookupPolicyRestrictor(location);
             if (this.delegate != null) {

--- a/hawtio-system/src/main/java/io/hawt/web/ServletHelpers.java
+++ b/hawtio-system/src/main/java/io/hawt/web/ServletHelpers.java
@@ -5,14 +5,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.URL;
-
 import javax.management.AttributeNotFoundException;
+
 import jakarta.servlet.http.HttpServletResponse;
 
 import io.hawt.system.Authenticator;
 import io.hawt.util.IOHelper;
-import org.jolokia.converter.Converters;
-import org.jolokia.converter.json.JsonConvertOptions;
+import org.jolokia.server.core.service.serializer.SerializeOptions;
+import org.jolokia.service.serializer.JolokiaSerializer;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +27,8 @@ public class ServletHelpers {
     private static final Logger LOG = LoggerFactory.getLogger(ServletHelpers.class);
 
     private static final String HEADER_WWW_AUTHENTICATE = "WWW-Authenticate";
+
+    private static final JolokiaSerializer SERIALIZER = new JolokiaSerializer();
 
     public static void doForbidden(HttpServletResponse response) {
         doForbidden(response, ForbiddenReason.NONE);
@@ -78,11 +80,11 @@ public class ServletHelpers {
         out.close();
     }
 
-    public static void writeObject(Converters converters, JsonConvertOptions options, PrintWriter out, Object data) {
+    public static void writeObjectAsJson(PrintWriter out, Object data) {
         Object result = null;
 
         try {
-            result = converters.getToJsonConverter().convertToJson(data, null, options);
+            result = SERIALIZER.serialize(data, null, SerializeOptions.DEFAULT);
         } catch (AttributeNotFoundException e) {
             LOG.warn("Failed to convert object to json", e);
         }

--- a/hawtio-system/src/main/java/io/hawt/web/auth/LoginServlet.java
+++ b/hawtio-system/src/main/java/io/hawt/web/auth/LoginServlet.java
@@ -7,8 +7,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.security.auth.Subject;
+
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -17,8 +17,6 @@ import io.hawt.system.AuthHelpers;
 import io.hawt.system.AuthenticateResult;
 import io.hawt.system.Authenticator;
 import io.hawt.web.ServletHelpers;
-import org.jolokia.converter.Converters;
-import org.jolokia.converter.json.JsonConvertOptions;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,9 +34,6 @@ public class LoginServlet extends HttpServlet {
 
     protected int timeout;
     protected AuthenticationConfiguration authConfiguration;
-
-    private final Converters converters = new Converters();
-    private final JsonConvertOptions options = JsonConvertOptions.DEFAULT;
 
     private Redirector redirector = new Redirector();
 
@@ -115,7 +110,7 @@ public class LoginServlet extends HttpServlet {
             answer.put("principals", principals);
             answer.put("credentials", credentials);
 
-            ServletHelpers.writeObject(converters, options, out, answer);
+            ServletHelpers.writeObjectAsJson(out, answer);
         } catch (IOException e) {
             LOG.error("Failed to send response", e);
         }

--- a/hawtio-system/src/main/java/io/hawt/web/plugin/PluginServlet.java
+++ b/hawtio-system/src/main/java/io/hawt/web/plugin/PluginServlet.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import javax.management.Attribute;
 import javax.management.AttributeList;
 import javax.management.InstanceNotFoundException;
@@ -19,14 +18,13 @@ import javax.management.MalformedObjectNameException;
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
+
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import io.hawt.web.ServletHelpers;
-import org.jolokia.converter.Converters;
-import org.jolokia.converter.json.JsonConvertOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,8 +52,6 @@ public class PluginServlet extends HttpServlet {
 
     private MBeanServer mBeanServer;
     private ObjectName pluginQuery;
-    private final Converters converters = new Converters();
-    private final JsonConvertOptions options = JsonConvertOptions.DEFAULT;
 
     @Override
     public void init() throws ServletException {
@@ -99,7 +95,7 @@ public class PluginServlet extends HttpServlet {
             })
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
-        ServletHelpers.writeObject(converters, options, out, answer);
+        ServletHelpers.writeObjectAsJson(out, answer);
     }
 
     private boolean isPluginMBean(AttributeList attributeList) {

--- a/hawtio-system/src/main/java/io/hawt/web/servlets/JolokiaConfiguredAgentServlet.java
+++ b/hawtio-system/src/main/java/io/hawt/web/servlets/JolokiaConfiguredAgentServlet.java
@@ -8,8 +8,8 @@ import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 
-import org.jolokia.config.ConfigKey;
-import org.jolokia.http.AgentServlet;
+import org.jolokia.server.core.config.ConfigKey;
+import org.jolokia.server.core.http.AgentServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hawtio-system/src/test/java/io/hawt/system/RBACRestrictorTest.java
+++ b/hawtio-system/src/test/java/io/hawt/system/RBACRestrictorTest.java
@@ -16,12 +16,11 @@
 package io.hawt.system;
 
 import java.util.Arrays;
-
 import javax.management.InstanceNotFoundException;
 import javax.management.ObjectName;
 
 import io.hawt.jmx.JMXSecurity;
-import org.jolokia.config.Configuration;
+import org.jolokia.server.core.config.StaticConfiguration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,7 +52,7 @@ public class RBACRestrictorTest {
     public void noJMXSecurityMBean() throws Exception {
         // make sure no JMXSecurity MBean is registered
         this.mockJMXSecurity.destroy();
-        RBACRestrictor restrictor = new RBACRestrictor(new Configuration());
+        RBACRestrictor restrictor = new RBACRestrictor(new StaticConfiguration());
         assertThat(restrictor.isOperationAllowed(new ObjectName("hawtio:type=Test"), "anyMethod(java.lang.String)"), is(true));
         assertThat(restrictor.isAttributeReadAllowed(new ObjectName("java.lang:type=Runtime"), "VmName"), is(true));
         assertThat(restrictor.isAttributeWriteAllowed(new ObjectName("java.lang:type=Runtime"), "VmName"), is(true));
@@ -61,7 +60,7 @@ public class RBACRestrictorTest {
 
     @Test
     public void isOperationAllowed() throws Exception {
-        RBACRestrictor restrictor = new RBACRestrictor(new Configuration());
+        RBACRestrictor restrictor = new RBACRestrictor(new StaticConfiguration());
 
         assertThat(restrictor.isOperationAllowed(new ObjectName("hawtio:type=Test"), "allowed()"), is(true));
         assertThat(restrictor.isOperationAllowed(new ObjectName("hawtio:type=Test"), "notAllowed()"), is(false));
@@ -74,7 +73,7 @@ public class RBACRestrictorTest {
 
     @Test
     public void isAttributeReadAllowed() throws Exception {
-        RBACRestrictor restrictor = new RBACRestrictor(new Configuration());
+        RBACRestrictor restrictor = new RBACRestrictor(new StaticConfiguration());
         assertThat(restrictor.isAttributeReadAllowed(new ObjectName("java.lang:type=Runtime"), "VmName"), is(true));
         assertThat(restrictor.isAttributeReadAllowed(new ObjectName("java.lang:type=Memory"), "Verbose"), is(true));
         assertThat(restrictor.isAttributeReadAllowed(new ObjectName("java.lang:type=Runtime"), "VmVersion"), is(false));
@@ -84,7 +83,7 @@ public class RBACRestrictorTest {
 
     @Test
     public void isAttributeWriteAllowed() throws Exception {
-        RBACRestrictor restrictor = new RBACRestrictor(new Configuration());
+        RBACRestrictor restrictor = new RBACRestrictor(new StaticConfiguration());
         assertThat(restrictor.isAttributeWriteAllowed(new ObjectName("java.lang:type=Memory"), "Verbose"), is(true));
         assertThat(restrictor.isAttributeWriteAllowed(new ObjectName("java.lang:type=Runtime"), "VmVersion"), is(false));
         assertThat(restrictor.isAttributeWriteAllowed(new ObjectName("java.lang:type=Runtime"), "xxx"), is(false));

--- a/hawtio-system/src/test/java/io/hawt/web/ServletHelpersTest.java
+++ b/hawtio-system/src/test/java/io/hawt/web/ServletHelpersTest.java
@@ -11,8 +11,6 @@ import java.util.Map;
 
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.jolokia.converter.Converters;
-import org.jolokia.converter.json.JsonConvertOptions;
 import org.json.JSONObject;
 import org.junit.Test;
 
@@ -42,17 +40,15 @@ public class ServletHelpersTest {
     }
 
     @Test
-    public void writeObject() {
-        Converters converters = new Converters();
-        JsonConvertOptions options = JsonConvertOptions.DEFAULT;
+    public void writeObjectAsJson() {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        ServletHelpers.writeObject(converters, options, new PrintWriter(out), Collections.emptyList());
+        ServletHelpers.writeObjectAsJson(new PrintWriter(out), Collections.emptyList());
         assertThat(out.toString(), equalTo("[]"));
 
         out.reset();
         Object obj = Map.of("string", "text", "number", 2, "boolean", true);
-        ServletHelpers.writeObject(converters, options, new PrintWriter(out), obj);
+        ServletHelpers.writeObjectAsJson(new PrintWriter(out), obj);
         assertThat(out.toString(), equalTo("{\"number\":2,\"boolean\":true,\"string\":\"text\"}"));
     }
 

--- a/platforms/springboot/pom.xml
+++ b/platforms/springboot/pom.xml
@@ -26,6 +26,7 @@
   </dependencyManagement>
 
   <dependencies>
+    <!-- Hawtio -->
     <dependency>
       <groupId>io.hawt</groupId>
       <artifactId>hawtio-war</artifactId>
@@ -50,6 +51,8 @@
       <version>${project.version}</version>
       <optional>true</optional>
     </dependency>
+
+    <!-- Spring Boot -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator</artifactId>

--- a/platforms/springboot/src/main/java/io/hawt/springboot/HawtioEndpoint.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/HawtioEndpoint.java
@@ -63,15 +63,15 @@ public class HawtioEndpoint implements WebMvcConfigurer {
         // @formatter:off
         // Hawtio React static resources
         registry
-            .addResourceHandler(endpointPath.resolveUrlMapping("hawtio", "/static/**"))
-            .addResourceLocations(
-                "/static/",
-                "classpath:/hawtio-static/static/");
-        registry
             .addResourceHandler(endpointPath.resolveUrlMapping("hawtio", "/**"))
             .addResourceLocations(
                 "/",
                 "classpath:/hawtio-static/");
+        registry
+            .addResourceHandler(endpointPath.resolveUrlMapping("hawtio", "/static/**"))
+            .addResourceLocations(
+                "/static/",
+                "classpath:/hawtio-static/static/");
         registry
             .addResourceHandler(endpointPath.resolveUrlMapping("hawtio", "/img/**"))
             .addResourceLocations("classpath:/hawtio-static/img/");

--- a/platforms/springboot/src/main/java/io/hawt/springboot/HawtioEndpoint.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/HawtioEndpoint.java
@@ -1,13 +1,13 @@
 package io.hawt.springboot;
 
 import java.util.List;
+
 import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpoint;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -68,26 +68,14 @@ public class HawtioEndpoint implements WebMvcConfigurer {
                 "/static/",
                 "classpath:/hawtio-static/static/");
         registry
-            .addResourceHandler(endpointPath.resolveUrlMapping("hawtio", "/plugins/**"))
-            .addResourceLocations(
-                "/app/",
-                "classpath:/hawtio-static/app/");
-        registry
             .addResourceHandler(endpointPath.resolveUrlMapping("hawtio", "/**"))
             .addResourceLocations(
                 "/",
-                "/app/",
-                "classpath:/hawtio-static/",
-                "classpath:/hawtio-static/app/");
+                "classpath:/hawtio-static/");
         registry
             .addResourceHandler(endpointPath.resolveUrlMapping("hawtio", "/img/**"))
             .addResourceLocations("classpath:/hawtio-static/img/");
         // @formatter:on
-    }
-
-    @Override
-    public void configurePathMatch(PathMatchConfigurer configurer) {
-        configurer.setUseTrailingSlashMatch(true);
     }
 }
 

--- a/platforms/springboot/src/main/java/io/hawt/springboot/HawtioManagementConfiguration.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/HawtioManagementConfiguration.java
@@ -6,11 +6,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
 import javax.annotation.Nonnull;
 
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.DispatcherType;
+import jakarta.servlet.http.HttpServletRequest;
 
 import io.hawt.system.ConfigManager;
 import io.hawt.web.auth.AuthenticationConfiguration;
@@ -108,6 +107,19 @@ public class HawtioManagementConfiguration {
     // -------------------------------------------------------------------------
     // Filters
     // -------------------------------------------------------------------------
+
+    /**
+     * Since Spring Boot 3.0, paths with trailing slash are not automatically processed
+     * and need to be explicitly configured for handling them. This Spring Boot
+     * specific filter redirects requests for hawtio/ to hawtio/index.html.
+     */
+    @Bean
+    public FilterRegistrationBean<TrailingSlashFilter> trailingSlashFilter(final Redirector redirector) {
+        final FilterRegistrationBean<TrailingSlashFilter> filter = new FilterRegistrationBean<>();
+        filter.setFilter(new TrailingSlashFilter(redirector));
+        filter.addUrlPatterns(hawtioPath + "/");
+        return filter;
+    }
 
     @Bean
     public FilterRegistrationBean<SessionExpiryFilter> sessionExpiryFilter() {

--- a/platforms/springboot/src/main/java/io/hawt/springboot/JolokiaEndpoint.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/JolokiaEndpoint.java
@@ -3,8 +3,7 @@ package io.hawt.springboot;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import org.jolokia.http.AgentServlet;
-
+import org.jolokia.server.core.http.AgentServlet;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.web.EndpointServlet;
 import org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpoint;

--- a/platforms/springboot/src/main/java/io/hawt/springboot/JolokiaEndpointAutoConfiguration.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/JolokiaEndpointAutoConfiguration.java
@@ -1,8 +1,6 @@
 package io.hawt.springboot;
 
-import io.hawt.springboot.JolokiaEndpoint;
-import io.hawt.springboot.JolokiaProperties;
-import org.jolokia.http.AgentServlet;
+import org.jolokia.server.core.http.AgentServlet;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;

--- a/platforms/springboot/src/main/java/io/hawt/springboot/TrailingSlashFilter.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/TrailingSlashFilter.java
@@ -1,0 +1,40 @@
+package io.hawt.springboot;
+
+import java.io.IOException;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import io.hawt.web.auth.Redirector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TrailingSlashFilter implements Filter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TrailingSlashFilter.class);
+
+    private final Redirector redirector;
+
+    public TrailingSlashFilter(Redirector redirector) {
+        this.redirector = redirector;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        LOG.trace("Applying {}", getClass().getSimpleName());
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+        if (!httpRequest.getRequestURI().endsWith("/")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        redirector.doRedirect(httpRequest, httpResponse, "/index.html");
+    }
+}

--- a/plugins/hawtio-local-jvm-mbean/pom.xml
+++ b/plugins/hawtio-local-jvm-mbean/pom.xml
@@ -23,8 +23,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jolokia</groupId>
-      <artifactId>jolokia-jvm</artifactId>
+      <!-- <groupId>org.jolokia</groupId> -->
+      <groupId>com.github.jolokia.jolokia</groupId>
+      <artifactId>jolokia-agent-jvm</artifactId>
       <version>${jolokia-version}</version>
       <exclusions>
         <exclusion>
@@ -71,23 +72,6 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-        <id>pre-java9</id>
-        <dependencies>
-            <dependency>
-                <groupId>com.sun</groupId>
-                <artifactId>tools</artifactId>
-                <version>1.6.0</version>
-                <scope>system</scope>
-                <systemPath>${java.home}/../lib/tools.jar</systemPath>
-            </dependency>
-        </dependencies>
-        <activation>
-            <file>
-                <exists>${java.home}/../lib/tools.jar</exists>
-            </file>
-        </activation>
-     </profile>
   </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,11 @@
           <artifactId>docker-maven-plugin</artifactId>
           <version>${docker-plugin-version}</version>
         </plugin>
+        <plugin>
+          <groupId>org.eclipse.jetty.ee10</groupId>
+          <artifactId>jetty-ee10-maven-plugin</artifactId>
+          <version>${jetty-plugin-version}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,9 @@
     <jackson-version-range>[2.8,3)</jackson-version-range>
     <jetty-version>12.0.1</jetty-version>
     <jetty-plugin-version>${jetty-version}</jetty-plugin-version>
-    <jolokia-version>2.0.0-SNAPSHOT</jolokia-version>
+    <!-- <jolokia-version>2.0.0-SNAPSHOT</jolokia-version> -->
+    <!-- jitpack snapshot of jolokia -->
+    <jolokia-version>2.0-SNAPSHOT</jolokia-version>
     <junit-version>4.13.2</junit-version>
     <junit5-version>5.9.3</junit5-version>
     <karaf-version>4.3.3</karaf-version>
@@ -120,7 +122,7 @@
     <module>examples/springboot</module>
     <module>examples/springboot-authentication</module>
     <module>examples/springboot-authentication-jar</module>
-<!--    <module>examples/springboot-keycloak</module>-->
+    <!-- <module>examples/springboot-keycloak</module> -->
     <module>examples/springboot-log4j2</module>
     <module>examples/springboot-plugin</module>
     <module>examples/springboot-security</module>
@@ -131,7 +133,7 @@
     <module>hawtio-war</module>
     <module>platforms/quarkus</module>
     <module>platforms/springboot</module>
-<!--    <module>platforms/springboot-keycloak</module>-->
+    <!-- <module>platforms/springboot-keycloak</module> -->
     <module>plugins/hawtio-local-jvm-mbean</module>
     <module>plugins/hawtio-log-logback</module>
     <module>plugins/hawtio-log</module>
@@ -357,5 +359,13 @@
       </build>
     </profile>
   </profiles>
+
+  <!-- Temporarily used for Jolokia 2.0.0 snapshot -->
+  <repositories>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
+  </repositories>
 
 </project>

--- a/tests/quarkus/src/main/java/io/hawt/tests/quarkus/SampleCamelRoute.java
+++ b/tests/quarkus/src/main/java/io/hawt/tests/quarkus/SampleCamelRoute.java
@@ -1,8 +1,8 @@
 package io.hawt.tests.quarkus;
 
-import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
+import jakarta.enterprise.context.ApplicationScoped;
 
-import javax.enterprise.context.ApplicationScoped;
+import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
 
 @ApplicationScoped
 public class SampleCamelRoute extends EndpointRouteBuilder {

--- a/tests/springboot/src/main/java/io/hawt/tests/spring/boot/PropertyFileLoginModule.java
+++ b/tests/springboot/src/main/java/io/hawt/tests/spring/boot/PropertyFileLoginModule.java
@@ -1,20 +1,16 @@
 package io.hawt.tests.spring.boot;
 
-import java.security.Principal;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
+import java.util.stream.Collectors;
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
 
 import org.eclipse.jetty.jaas.spi.AbstractLoginModule;
-import org.eclipse.jetty.jaas.spi.UserInfo;
 import org.eclipse.jetty.security.PropertyUserStore;
-import org.eclipse.jetty.server.UserIdentity;
-import org.eclipse.jetty.util.security.Credential;
+import org.eclipse.jetty.security.RolePrincipal;
+import org.eclipse.jetty.security.UserPrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,27 +66,38 @@ public class PropertyFileLoginModule extends AbstractLoginModule {
     }
 
     @Override
-    public UserInfo getUserInfo(final String userName) {
+    public JAASUser getUser(String userName) {
         final PropertyUserStore propertyUserStore = PROPERTY_USERSTORES.get(filename);
         if (propertyUserStore == null) {
             throw new IllegalStateException("PropertyUserStore should never be null here!");
         }
 
         LOG.trace("Checking PropertyUserStore " + filename + " for " + userName);
-        final UserIdentity userIdentity = propertyUserStore.getUserIdentity(userName);
-        if (userIdentity == null) {
+        final UserPrincipal userPrincipal = propertyUserStore.getUserPrincipal(userName);
+        final List<RolePrincipal> rolePrincipals = propertyUserStore.getRolePrincipals(userName);
+
+        if (userPrincipal == null || rolePrincipals == null) {
             return null;
         }
 
-        final Set<Principal> principals = userIdentity.getSubject().getPrincipals();
-        final List<String> roles = new ArrayList<>();
-        for (final Principal principal : principals) {
-            roles.add(principal.getName());
+        final List<String> roles = rolePrincipals.stream().map(RolePrincipal::getName).collect(Collectors.toList());
+
+        LOG.trace("Found: " + userName + " in PropertyUserStore " + filename);
+        return new HawtioJAASUser(userPrincipal, roles);
+    }
+
+    static class HawtioJAASUser extends JAASUser {
+        List<String> roles;
+
+        public HawtioJAASUser(UserPrincipal userPrincipal, List<String> roles) {
+            super(userPrincipal);
+            this.roles = roles;
         }
 
-        final Credential credential = (Credential) userIdentity.getSubject().getPrivateCredentials().iterator().next();
-        LOG.trace("Found: " + userName + " in PropertyUserStore " + filename);
-        return new UserInfo(userName, credential, roles);
+        @Override
+        public List<String> doFetchRoles() {
+            return roles;
+        }
     }
 
     @Override

--- a/tests/springboot/src/main/java/io/hawt/tests/spring/boot/SampleCamelRouter.java
+++ b/tests/springboot/src/main/java/io/hawt/tests/spring/boot/SampleCamelRouter.java
@@ -1,7 +1,6 @@
 package io.hawt.tests.spring.boot;
 
 import org.apache.camel.builder.RouteBuilder;
-
 import org.springframework.stereotype.Component;
 
 @Component

--- a/tests/springboot/src/main/java/io/hawt/tests/spring/boot/SpringBootService.java
+++ b/tests/springboot/src/main/java/io/hawt/tests/spring/boot/SpringBootService.java
@@ -2,7 +2,7 @@ package io.hawt.tests.spring.boot;
 
 import java.util.Optional;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import io.hawt.springboot.HawtioPlugin;
 import io.hawt.web.auth.AuthenticationConfiguration;


### PR DESCRIPTION
Applied the official Jolokia 2.0.0-SNAPSHOT artifacts to 4.x branch. Right now, it uses jitpack for CI to resolve the snapshot jar dependencies. Once we have a new Jolokia 2.0.0 milestone release, we can remove the jitpack usage.

cc @mmelko 

should fix #2866 #2867 #2868 