### PR TITLE
ci: HAWNG-281 apply yarn npm audit to workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,22 @@
+name: Audit
+
+on:
+  schedule:
+    # Run it every Sunday
+    - cron: '0 0 * * 0'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'maven'
+      - name: Audit
+        run: |
+          mvn --batch-mode --no-transfer-progress install -pl :hawtio-console-assembly,:hawtio-example-sample-plugin

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -39,6 +39,15 @@
             </configuration>
           </execution>
           <execution>
+            <id>yarn npm audit</id>
+            <goals>
+              <goal>yarn</goal>
+            </goals>
+            <configuration>
+              <arguments>npm audit --all</arguments>
+            </configuration>
+          </execution>
+          <execution>
             <id>yarn install</id>
             <goals>
               <goal>yarn</goal>

--- a/examples/sample-plugin/pom.xml
+++ b/examples/sample-plugin/pom.xml
@@ -58,6 +58,15 @@
             </configuration>
           </execution>
           <execution>
+            <id>yarn npm audit</id>
+            <goals>
+              <goal>yarn</goal>
+            </goals>
+            <configuration>
+              <arguments>npm audit --all</arguments>
+            </configuration>
+          </execution>
+          <execution>
             <id>yarn install</id>
             <goals>
               <goal>yarn</goal>


### PR DESCRIPTION
This adds a new workflow 'Audit', which runs weekly on every Sunday to periodically audit the npm dependencies.

It also inserts audit steps to building of console and sample-plugin, so that every pull request is also audited against the potentially added dependencies.