### PR TITLE
build: Bump Node versions update for maven frontend plugin

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -13,11 +13,6 @@
   <description>Hawtio :: ${project.artifactId}</description>
   <packaging>pom</packaging>
 
-  <properties>
-    <node-version>v18.18.2</node-version>
-    <yarn-version>v1.22.19</yarn-version>
-  </properties>
-
   <build>
     <plugins>
 

--- a/examples/sample-plugin/pom.xml
+++ b/examples/sample-plugin/pom.xml
@@ -16,9 +16,6 @@
   <description>Hawtio :: Sample Hawtio plugin TypeScript project</description>
 
   <properties>
-    <!-- node & yarn versions used for build -->
-    <node-version>v18.18.2</node-version>
-    <yarn-version>v1.22.19</yarn-version>
     <!--
       Path to the Hawtio plugin TS project. You can specify the path if it's placed
       differently from the project root.

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,10 @@
     <spring-hateoas-version>0.25.0.RELEASE</spring-hateoas-version>
     <spring-plugin-core-version>1.2.0.RELEASE</spring-plugin-core-version>
     <docker-plugin-version>0.43.0</docker-plugin-version>
+
+    <!-- Used for maven-frontend-plugin -->
+    <node-version>v20.9.0</node-version>
+    <yarn-version>v1.22.21</yarn-version>
   </properties>
 
   <modules>


### PR DESCRIPTION
This is needed as with older Node versions connection through IPv6 was unstable. This should fix the issue. 
Btw @tadayosi what do you think about moving these properties to the parent pom so we can upgrade the versions in just one place?