### PR TITLE
feat(jbang): support red hat maven repositories for jbang

### DIFF
--- a/hawtio-jbang/dist/HawtioJBang.java
+++ b/hawtio-jbang/dist/HawtioJBang.java
@@ -19,7 +19,7 @@
  */
 
 //JAVA 11+
-//REPOS mavencentral
+//REPOS mavencentral,redhat-ga=https://maven.repository.redhat.com/ga,redhat-ea=https://maven.repository.redhat.com/earlyaccess/all
 //DEPS io.hawt:hawtio-embedded:${hawtio.jbang.version:4.0-beta-1}
 
 package main;

--- a/hawtio-jbang/src/main/jbang/main/HawtioJBang.java
+++ b/hawtio-jbang/src/main/jbang/main/HawtioJBang.java
@@ -19,7 +19,7 @@
  */
 
 //JAVA 11+
-//REPOS mavencentral
+//REPOS mavencentral,redhat-ga=https://maven.repository.redhat.com/ga,redhat-ea=https://maven.repository.redhat.com/earlyaccess/all
 //DEPS io.hawt:hawtio-embedded:${hawtio.jbang.version:4.0-beta-1}
 
 package main;


### PR DESCRIPTION
This should enable users to run a Hawtio version provided on MRRC as follows:

```console
jbang -Dhawtio.jbang.version=4.0.0.redhat-00029 hawtio@hawtio/hawtio
```

@Croway Please review this to check if I'm doing it correctly.