### PR TITLE
fix(ProxyServlet): Refactor how url being created when 300-303 status is received

### DIFF
--- a/hawtio-system/src/main/java/io/hawt/web/proxy/ProxyServlet.java
+++ b/hawtio-system/src/main/java/io/hawt/web/proxy/ProxyServlet.java
@@ -341,7 +341,7 @@ public class ProxyServlet extends HttpServlet {
                     + " but no " + HttpHeaders.LOCATION + " header was found in the response");
             }
 
-            String locStr = rewriteUrlFromResponse(servletRequest,locationHeader.getValue(), Strings.sanitize(targetUriObj.toString()));
+            String locStr = rewriteUrlFromResponse(servletRequest,locationHeader.getValue(), targetUriObj.toString());
             servletResponse.sendRedirect(locStr);
             return true;
         }
@@ -452,14 +452,15 @@ public class ProxyServlet extends HttpServlet {
      */
     protected String rewriteUrlFromResponse(HttpServletRequest servletRequest, String theUrl, String targetUri) {
         //TODO document example paths
+
         if (theUrl.startsWith(targetUri)) {
-            String curUrl = servletRequest.getRequestURL().toString();//no query
-            String pathInfo = servletRequest.getPathInfo();
-            if (pathInfo != null) {
-                assert curUrl.endsWith(pathInfo);
-                curUrl = curUrl.substring(0, curUrl.length() - pathInfo.length());//take pathInfo off
-            }
-            theUrl = curUrl + theUrl.substring(targetUri.length());
+           String curUrl = String.format("%s://%s:%s%s%s", servletRequest.getScheme(),
+               servletRequest.getServerName(),
+               servletRequest.getServerPort(),
+               servletRequest.getContextPath(),
+               servletRequest.getServletPath());
+
+            theUrl = curUrl + theUrl.substring(targetUri.length() - 1);
         }
         return theUrl;
     }


### PR DESCRIPTION
I rewrote how URL is crafted. This should prevent open redirect vulnerability.  This code is reachable only when status from the proxy is between 300 and 303 (when redirect is necessary) which is not  often AFAIK.  
