### PR TITLE
fix(HAWNG-5): Remove unsafe-eval and unsafe-inline from the CSP header

### DIFF
--- a/hawtio-system/src/main/java/io/hawt/web/filters/ContentSecurityPolicyFilter.java
+++ b/hawtio-system/src/main/java/io/hawt/web/filters/ContentSecurityPolicyFilter.java
@@ -28,8 +28,8 @@ public class ContentSecurityPolicyFilter extends HttpHeaderFilter {
 
     private static final String POLICY_TEMPLATE =
         "default-src 'self'; " +
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval' %s; " +
-            "style-src 'self' 'unsafe-inline'; " +
+            "script-src 'self' %s; " +
+            "style-src 'self'; " +
             "font-src 'self' data:; " +
             "img-src 'self' data:; " +
             "connect-src 'self' %s; " +

--- a/hawtio-system/src/test/java/io/hawt/web/filters/ContentSecurityPolicyFilterTest.java
+++ b/hawtio-system/src/test/java/io/hawt/web/filters/ContentSecurityPolicyFilterTest.java
@@ -52,8 +52,8 @@ public class ContentSecurityPolicyFilterTest {
         contentSecurityPolicyFilter.addHeaders(request, response);
         // then
         verify(response).addHeader("Content-Security-Policy",
-            "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' ; "
-                + "style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; "
+            "default-src 'self'; script-src 'self' ; "
+                + "style-src 'self'; font-src 'self' data:; img-src 'self' data:; "
                 + "connect-src 'self' ; frame-src 'self' ; "
                 + "frame-ancestors 'none'");
     }
@@ -67,8 +67,8 @@ public class ContentSecurityPolicyFilterTest {
         contentSecurityPolicyFilter.addHeaders(request, response);
         // then
         verify(response).addHeader("Content-Security-Policy",
-            "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:8180; "
-                + "style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; "
+            "default-src 'self'; script-src 'self' http://localhost:8180; "
+                + "style-src 'self'; font-src 'self' data:; img-src 'self' data:; "
                 + "connect-src 'self' http://localhost:8180; frame-src 'self' http://localhost:8180; "
                 + "frame-ancestors 'none'");
     }
@@ -82,8 +82,8 @@ public class ContentSecurityPolicyFilterTest {
         contentSecurityPolicyFilter.addHeaders(request, response);
         // then
         verify(response).addHeader("Content-Security-Policy",
-            "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:8180; "
-                + "style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; "
+            "default-src 'self'; script-src 'self' http://localhost:8180; "
+                + "style-src 'self'; font-src 'self' data:; img-src 'self' data:; "
                 + "connect-src 'self' http://localhost:8180; frame-src 'self' http://localhost:8180; "
                 + "frame-ancestors 'none'");
     }
@@ -97,7 +97,7 @@ public class ContentSecurityPolicyFilterTest {
         contentSecurityPolicyFilter.addHeaders(request, response);
         // then
         verify(response).addHeader(eq("Content-Security-Policy"), eq(
-            "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' ; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' ; frame-src 'self' ; frame-ancestors 'none'"));
+            "default-src 'self'; script-src 'self' ; style-src 'self'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' ; frame-src 'self' ; frame-ancestors 'none'"));
     }
 
     @Test
@@ -109,8 +109,8 @@ public class ContentSecurityPolicyFilterTest {
         contentSecurityPolicyFilter.addHeaders(request, response);
         // then
         verify(response).addHeader("Content-Security-Policy",
-            "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' ; "
-                + "style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; "
+            "default-src 'self'; script-src 'self' ; "
+                + "style-src 'self'; font-src 'self' data:; img-src 'self' data:; "
                 + "connect-src 'self' ; frame-src 'self' ; "
                 + "frame-ancestors 'self'");
     }


### PR DESCRIPTION
Looks like we don't need this for the nawtio-next and we are not using inline scrips. I also verified that CSP header is modified and hawtio is working with this settings. 