### PR TITLE
Add screenshots to Report Portal + fix flaky Openshift tests

### DIFF
--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/pages/openshift/HawtioOnlineLoginPage.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/pages/openshift/HawtioOnlineLoginPage.java
@@ -2,7 +2,12 @@ package io.hawt.tests.features.pageobjects.pages.openshift;
 
 import static com.codeborne.selenide.Selenide.$;
 
+import org.junit.Assert;
+
+import org.assertj.core.api.Assertions;
 import org.openqa.selenium.By;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Selenide;
@@ -12,11 +17,26 @@ import com.codeborne.selenide.ex.ElementNotFound;
 import java.time.Duration;
 
 import io.hawt.tests.features.openshift.WaitUtils;
+import io.hawt.tests.features.utils.ByUtils;
 
 public class HawtioOnlineLoginPage {
 
+    private static final Logger LOG = LoggerFactory.getLogger(HawtioOnlineLoginPage.class);
+
     public void login(String username, String password) {
         WaitUtils.waitForPageLoad();
+
+        final By appUnavailableSelector = ByUtils.byText("h1", "Application is not available");
+        if ($(appUnavailableSelector).exists()) {
+            LOG.info("Application is not available, let's wait and reload :)");
+            WaitUtils.wait(Duration.ofSeconds(10));
+            Selenide.refresh();
+            WaitUtils.waitForPageLoad();
+            if ($(appUnavailableSelector).exists()) {
+                Assertions.assertThat($(appUnavailableSelector).exists()).withFailMessage(() -> "App wasn't available in time :(").isFalse();
+            }
+        }
+
         final By loginButtonSelector = By.cssSelector("a[title=\"Log in with my_htpasswd_provider\"]");
 
         try {

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/utils/SelenideTestWatcher.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/utils/SelenideTestWatcher.java
@@ -5,6 +5,12 @@ import org.junit.jupiter.api.extension.TestWatcher;
 
 import com.codeborne.selenide.Selenide;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import io.hawt.tests.utils.rp.Attachments;
+
 public class SelenideTestWatcher implements TestWatcher {
 
     @Override
@@ -13,8 +19,10 @@ public class SelenideTestWatcher implements TestWatcher {
     }
 
     private static void takeScreenshot(ExtensionContext context) {
-        var screenshot = Selenide.screenshot(context.getRequiredTestClass().getName() + "#" + context.getRequiredTestMethod().getName());
+        var screenshot = URLDecoder.decode(Selenide.screenshot(context.getRequiredTestClass().getName() + "." + context.getRequiredTestMethod().getName()),
+            StandardCharsets.UTF_8);
         context.publishReportEntry("screenshot", screenshot);
+        Attachments.addAttachment(Path.of(screenshot.substring("file:".length())));
     }
 
     @Override

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/utils/rp/Attachments.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/utils/rp/Attachments.java
@@ -1,0 +1,73 @@
+package io.hawt.tests.utils.rp;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class Attachments {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Attachments.class);
+    private static final List<Path> testClassAttachments = new ArrayList<>();
+    private static final List<Path> testCaseAttachments = new ArrayList<>();
+    private static String currentTestCase;
+    private static String currentTestClass;
+
+    private Attachments() {
+    }
+
+    static void startTestClass(String testClass) {
+        currentTestClass = testClass;
+    }
+
+    static void startTestCase(String testCase) {
+        currentTestCase = testCase;
+    }
+
+    static void endTestCase(boolean failure) {
+        if (failure) {
+            createAttachments(Stream.concat(testClassAttachments.stream(), testCaseAttachments.stream()).collect(Collectors.toList()),
+                currentTestClass + "." + currentTestCase);
+        }
+        testCaseAttachments.clear();
+        currentTestCase = null;
+    }
+
+    static void endTestClass() {
+        testClassAttachments.clear();
+        currentTestClass = null;
+    }
+
+    private static void createAttachments(List<Path> attachments, String folder) {
+        if (attachments.isEmpty()) {
+            return;
+        }
+
+        try {
+            final Path testCaseDir = Path.of("target", "attachments", folder);
+            Files.createDirectories(testCaseDir);
+
+            for (Path p : attachments) {
+                Files.copy(p, testCaseDir.resolve(p.getFileName()));
+            }
+        } catch (IOException e) {
+            LOG.error("Couldn't create an attachment for test case {}#{}", currentTestClass, currentTestCase, e);
+        }
+    }
+
+    public static void addAttachment(Path path) {
+        LOG.info("Adding attachment: {}", path);
+        if (currentTestCase != null) {
+            testCaseAttachments.add(path);
+        } else {
+            testClassAttachments.add(path);
+        }
+    }
+}
+

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/utils/rp/RPTestExecutionListener.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/utils/rp/RPTestExecutionListener.java
@@ -1,0 +1,43 @@
+package io.hawt.tests.utils.rp;
+
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+
+import com.google.auto.service.AutoService;
+
+@AutoService(TestExecutionListener.class)
+public class RPTestExecutionListener implements TestExecutionListener {
+
+    private static String transformReportingName(String name) {
+        return name.replace("()", "").replace("(", "{").replace(")", "}");
+    }
+
+    @Override
+    public void executionStarted(TestIdentifier testIdentifier) {
+        if (testIdentifier.isTest()) {
+            Attachments.startTestCase(transformReportingName(testIdentifier.getLegacyReportingName()));
+        } else {
+            testIdentifier.getSource().ifPresent(source -> {
+                if (source instanceof ClassSource) {
+                    Attachments.startTestClass(((ClassSource) source).getClassName());
+                }
+            });
+        }
+    }
+
+    @Override
+    public void executionFinished(TestIdentifier testIdentifier,
+        TestExecutionResult testExecutionResult) {
+        if (testIdentifier.isTest()) {
+            Attachments.endTestCase(testExecutionResult.getThrowable().isPresent());
+        } else {
+            testIdentifier.getSource().ifPresent(source -> {
+                if (source instanceof ClassSource) {
+                    Attachments.endTestClass();
+                }
+            });
+        }
+    }
+}

--- a/tests/hawtio-test-suite/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/tests/hawtio-test-suite/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+io.hawt.tests.utils.rp.RPTestExecutionListener


### PR DESCRIPTION
The RP client can attach files to specific test cases; this code screenshot is included with any failing test. 

+ fixed some flakiness when it came to testing on strained cluster & added logic to wait for the long initial load of Hawtio Online