### PR TITLE
fix(quarkus): quarkus when auth disabled should not fail to build without security extension

### DIFF
--- a/platforms/quarkus/deployment/pom.xml
+++ b/platforms/quarkus/deployment/pom.xml
@@ -79,6 +79,7 @@
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <quarkus.log.level>DEBUG</quarkus.log.level>
+            <!--suppress UnresolvedMavenProperty -->
             <maven.home>${maven.home}</maven.home>
           </systemPropertyVariables>
         </configuration>
@@ -94,6 +95,7 @@
             <configuration>
               <systemPropertyVariables>
                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                <!--suppress UnresolvedMavenProperty -->
                 <maven.home>${maven.home}</maven.home>
               </systemPropertyVariables>
             </configuration>

--- a/platforms/quarkus/runtime/src/main/java/io/hawt/quarkus/auth/HawtioQuarkusAuthenticator.java
+++ b/platforms/quarkus/runtime/src/main/java/io/hawt/quarkus/auth/HawtioQuarkusAuthenticator.java
@@ -4,17 +4,21 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 
 import io.hawt.system.AuthenticateResult;
 import io.hawt.util.Strings;
 import io.hawt.web.auth.AuthenticationConfiguration;
 import io.hawt.web.auth.AuthenticationThrottler;
+import io.quarkus.arc.DefaultBean;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.credential.PasswordCredential;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
 import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.smallrye.mutiny.Uni;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,5 +79,31 @@ public class HawtioQuarkusAuthenticator {
 
         String[] roles = roleConfig.split(",");
         return Arrays.stream(roles).anyMatch(identity.getRoles()::contains);
+    }
+
+    /**
+     * Default no-op identity provider manager.
+     * <p>
+     * It is used only when Hawtio authentication is disabled, but should never
+     * be invoked from anywhere at runtime.
+     * <p>
+     * When Hawtio authentication is enabled a security capability is required,
+     * so the user will need to provide a proper identity provider manager other
+     * than this no-op one to boot the application.
+     */
+    @Produces
+    @DefaultBean
+    public IdentityProviderManager noopIdentityProviderManager() {
+        return new IdentityProviderManager() {
+            @Override
+            public Uni<SecurityIdentity> authenticate(AuthenticationRequest request) {
+                return null;
+            }
+
+            @Override
+            public SecurityIdentity authenticateBlocking(AuthenticationRequest request) {
+                return null;
+            }
+        };
     }
 }


### PR DESCRIPTION
Fix #3307