### PR TITLE
fix(ci): fix build image job

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build images
         run: |
           mvn ${MVN_ARGS} install -Dquarkus.container-image.build=true -pl examples/quarkus
-          mvn ${MVN_ARGS} install -DskipTests -Pe2e -Pdocker-testsuite -Ptests-docker -Dhawtio-container -Ddocker.buildArg.JAVA_VERSION=${{ matrix.java }} -pl :hawtio-test-suite,:hawtio-tests-quarkus,:hawtio-tests-springboot -am
+          mvn ${MVN_ARGS} install -DskipTests -Pe2e -Pdocker-testsuite -Ptests-docker -Dhawtio-container -pl :hawtio-test-suite,:hawtio-tests-quarkus,:hawtio-tests-springboot -am
       - name: Display images
         run: |
           docker images


### PR DESCRIPTION
The fabric8 maven plugin fails when the same argument is specified in 2 different places (although in this case it had the same value). The values are now set automatically in the pom.xml from the current java version.