### PR TITLE
fix(connect): Handle redirect with "con" parameter for proxy requests

### DIFF
--- a/platforms/springboot/src/main/java/io/hawt/springboot/HawtioEndpoint.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/HawtioEndpoint.java
@@ -43,6 +43,10 @@ public class HawtioEndpoint implements WebMvcConfigurer {
         final String path = endpointPath.resolve("hawtio");
 
         if (request.getRequestURI().equals(path)) {
+            String query = request.getQueryString();
+            if (query != null && !query.isEmpty()) {
+                return "redirect:" + path + "/index.html?" + query;
+            }
             return "redirect:" + path + "/index.html";
         }
 

--- a/platforms/springboot/src/main/java/io/hawt/springboot/TrailingSlashFilter.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/TrailingSlashFilter.java
@@ -35,6 +35,11 @@ public class TrailingSlashFilter implements Filter {
             return;
         }
 
-        redirector.doRedirect(httpRequest, httpResponse, "/index.html");
+        String query = httpRequest.getQueryString();
+        if (query != null && !query.isEmpty()) {
+            redirector.doRedirect(httpRequest, httpResponse, "/index.html?" + query);
+        } else {
+            redirector.doRedirect(httpRequest, httpResponse, "/index.html");
+        }
     }
 }


### PR DESCRIPTION
When opening new connection tab from Hawtio on Spring Boot, we're getting redirected without con parameter. This commit fixes this problem.

Fixes #3317