### PR TITLE
fix: Upgrades springboot to 3.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,8 @@
     <!-- Quarkus -->
     <quarkus-version>3.8.2</quarkus-version>
     <!-- Spring -->
-    <spring-version>6.1.5</spring-version>
-    <spring-boot-version>3.2.3</spring-boot-version>
+    <spring-version>6.1.6</spring-version>
+    <spring-boot-version>3.2.5</spring-boot-version>
     <!-- Jetty -->
     <jetty-version>11.0.20</jetty-version>
     <!-- Keycloak -->


### PR DESCRIPTION
* The CVE requires the upgrade of spring products to 6.1.6+. To achieve this upgrade both the spring version and the springboot version in the pom configuration.

* See CVE described by https://spring.io/security/cve-2024-22262