### PR TITLE
e2e: rerun failed tests

### DIFF
--- a/tests/hawtio-test-suite/pom.xml
+++ b/tests/hawtio-test-suite/pom.xml
@@ -277,6 +277,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <skipTests>${skipTests}</skipTests>
+          <rerunFailingTestsCount>3</rerunFailingTestsCount>
           <systemProperties>
             <io.hawt.test.runtime>${test-runtime}</io.hawt.test.runtime>
             <io.hawt.test.url.suffix>${hawtio.url}</io.hawt.test.url.suffix>


### PR DESCRIPTION
This will rerun failed tests up to 3 times, the tests that pass on the retry are marked as flakes. For example: sometimes it happens that Hawtio doesn't load in time (there's about 30 second wait time), while we could always increase the wait time, it makes more sense to rerun the test again with the sensible time.