### PR TITLE
e2e: add camel-k integration to Hawtio Online tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -2,18 +2,11 @@
 
 ## Introduction
 
-E2E UI tests
-
 ### Test tools and frameworks
 
 - Selenium 4.x
 - Selenide 6.x
 - Cucumber 7.x
-
-### Runtime Support
-
-- Spring Boot 3.x
-- Quarkus 3.x
 
 ### Test scenarios cover the following areas
 
@@ -41,27 +34,29 @@ First of all, it's needed to build the project.
 mvn install -DskipTests
 ```
 
-### Spring Boot 3.x E2E tests
+### Spring Boot E2E tests
 
 ```console
 mvn install -Pe2e,e2e-springboot -am -pl :hawtio-test-suite -Dlocal-app=true
 ```
 
-### Quarkus 3.x E2E tests
+### Quarkus E2E tests
 
 ```console
 mvn install -Pe2e,e2e-quarkus -am -pl :hawtio-test-suite -Dlocal-app=true
 ```
 
+### Camel K E2E tests
+You need to provide an Openshift environment, either you need to be logged in to a cluster already or supply proper arguments you can find in the `io.hawt.tests.features.config.TestConfiguration` class.
+```console
+mvn install -Pe2e,e2e-camelk -am -pl :hawtio-test-suite -Dio.hawt.test.use.openshift=true
+```
+
 ### Additional Command Options
 
 - `-Dtest=` - defines the type of test set to be run.
-  - Spring Boot 3.x
-    - `SpringBootAllTest`
-    - `SpringBootSmokeTest`
-  - Quarkus 3.x
-    - `QuarkusAllTest`
-    - `QuarkusSmokeTest`
+  - `CucumberTest` executes the Cucumber teststsuite
+  - `<class name>` executes any other JUnit test
 
 #### Modes of execution
 
@@ -84,7 +79,7 @@ Build e2e containers with the following command: `mvn install -DskipTests -Pe2e 
 
 Resulting images are named hawtio-test-suite:<JAVA_VERSION>, hawtio-<quarkus|springboot>-app:<JAVA_VERSION>
 
-Default JAVA_VERSION is 11.
+Default JAVA_VERSION is 17.
 
 #### Running the containerized testsuite
 

--- a/tests/hawtio-test-suite/pom.xml
+++ b/tests/hawtio-test-suite/pom.xml
@@ -220,6 +220,14 @@
       </properties>
     </profile>
     <profile>
+      <id>e2e-camelk</id>
+      <properties>
+        <test-runtime>camelk</test-runtime>
+        <skipTests>false</skipTests>
+        <local-app>false</local-app>
+      </properties>
+    </profile>
+    <profile>
       <id>hawtio-container</id>
       <activation>
         <property>

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/config/TestConfiguration.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/config/TestConfiguration.java
@@ -47,6 +47,8 @@ public class TestConfiguration {
     public static final String OPENSHIFT_KUBECONFIG = "io.hawt.test.openshift.kubeconfig";
     public static final String OPENSHIFT_NAMESPACE_DELETE = "io.hawt.test.openshift.namespace.delete";
     public static final String OPENSHIFT_INDEX_IMAGE = "io.hawt.test.openshift.index.image";
+
+    public static final String CAMEL_K_CATALOG = "io.hawt.test.camelk.catalog";
     private static final String NAMESPACE_PREFIX = "hawtio-tests-";
 
     private static AppDeployment deployment;
@@ -191,6 +193,10 @@ public class TestConfiguration {
         return getBoolean(OPENSHIFT_NAMESPACE_DELETE, true);
     }
 
+
+    public static String getCamelKCatalog() {
+        return getProperty(CAMEL_K_CATALOG, "redhat-operators");
+    }
 
     public static String getRequiredProperty(String name) {
         return Objects.requireNonNull(System.getProperty(name), String.format("Missing required property value '%s'!", name));

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/OpenshiftClient.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/OpenshiftClient.java
@@ -31,7 +31,7 @@ public class OpenshiftClient extends OpenShift {
         if (TestConfiguration.getOpenshiftUrl() != null) {
             configBuilder = new OpenShiftConfigBuilder()
                 .withMasterUrl(TestConfiguration.getOpenshiftUrl())
-                .withUsername(TestConfiguration.getOpenshiftNamespace())
+                .withUsername(TestConfiguration.getOpenshiftUsername())
                 .withPassword(TestConfiguration.getOpenshiftPassword());
         } else if (TestConfiguration.openshiftKubeconfig() != null) {
             try {

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/openshift/PodEntry.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/openshift/PodEntry.java
@@ -92,6 +92,6 @@ public class PodEntry {
     }
 
     public void connect() {
-        $(root).$(By.className("pod-item-connect-button")).click();
+        $(root).$(By.cssSelector(".pod-item-connect-button > button")).click();
     }
 }

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/utils/HawtioOnlineTestUtils.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/utils/HawtioOnlineTestUtils.java
@@ -1,5 +1,6 @@
 package io.hawt.tests.utils;
 
+import org.junit.Assume;
 import org.junit.function.ThrowingRunnable;
 import org.junit.platform.commons.util.ExceptionUtils;
 
@@ -47,7 +48,7 @@ public class HawtioOnlineTestUtils {
     }
 
     public static void withPatchDeployment(Consumer<Deployment> action, ThrowingRunnable test) {
-
+        Assume.assumeTrue("App deployment exists",getAppDeployment() != null);
         AtomicReference<Deployment> prevDeployment = new AtomicReference<>();
 
         try {

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/panel/help/help.feature
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/panel/help/help.feature
@@ -22,10 +22,13 @@ Feature:  Checking the functionality of Help page.
       | tab           |
       | Home          |
       | Preferences   |
-      | Connect       |
       | JMX           |
       | Camel         |
 
     @notHawtioNext # - plugins are not present in hawtio-next CI runs
     Examples:
       | Sample Plugin |
+
+    @notOnline
+    Examples:
+      | Connect |

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/openshift/camelk-e2e-integration.groovy
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/openshift/camelk-e2e-integration.groovy
@@ -1,0 +1,9 @@
+from("quartz:cron?cron=0/10 * * * * ?").routeId("cron")
+            .setBody().constant("Hello Camel! - cron")
+            .to("stream:out")
+            .to("mock:result");
+
+from("quartz:simple?trigger.repeatInterval=10000").routeId("simple")
+            .setBody().constant("Hello Camel! - simple")
+            .to("stream:out")
+            .to("mock:result");


### PR DESCRIPTION
Allows using a Camel-K integration for E2E tests. Normally the latest Red Hat version from OperatorHub is used, but it can also be configured to use a different catalog by a property. 
Updated the readme to mention Camel K as well as changing / removing some outdated info. IMO it's not worth it to state the versions in the README as it's not always up to date with the pom 