### PR TITLE
fix(quarkus): Jolokia not working with Quarkus when building uber-jar

### DIFF
--- a/platforms/quarkus/deployment/src/main/java/io/hawt/quarkus/deployment/HawtioProcessor.java
+++ b/platforms/quarkus/deployment/src/main/java/io/hawt/quarkus/deployment/HawtioProcessor.java
@@ -31,6 +31,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
+import io.quarkus.deployment.pkg.builditem.UberJarMergedResourceBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeBuild;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
@@ -243,6 +244,11 @@ public class HawtioProcessor {
             .route(HawtioConfig.DEFAULT_PLUGIN_PATH)
             .handler(recorder.pluginHandler(config.pluginConfigs))
             .build();
+    }
+
+    @BuildStep
+    UberJarMergedResourceBuildItem mergeJolokiaServicesDefault() {
+        return new UberJarMergedResourceBuildItem("META-INF/jolokia/services-default");
     }
 
     @BuildStep(onlyIf = NativeBuild.class)


### PR DESCRIPTION
Fix #3495

@grgrzybek @jamesnetherton Wow, the fix turned out to be so simple!  Thanks James.

Now with the fix, `mvn clean install -Dquarkus.package.type=uber-jar -pl examples/quarkus` results in the following `META-INF/jolokia/services-default` in the uber-jar:
```java
# ============================================
# JSON Serializer
org.jolokia.service.serializer.JolokiaSerializer,10

# ============================================
# Request Handlers
org.jolokia.service.jmx.LocalRequestHandler,1000

# ============================================
# Discovery Listener and MBean registration
org.jolokia.service.discovery.JolokiaDiscovery
org.jolokia.service.discovery.DiscoveryMulticastResponder

# ============================================
# History MBean interceptor
org.jolokia.service.history.HistoryMBeanRequestInterceptor

# Single JSR-160 based Request handler
org.jolokia.service.jsr160.Jsr160RequestHandler

# ============================================
# Notification backend
org.jolokia.service.notif.pull.PullNotificationBackend

# ============================================
# Notification backend
org.jolokia.service.notif.sse.SseNotificationBackend
```

