### PR TITLE
[E2E Tests] Add tests checking Camel Route Properties tab

### DIFF
--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/routes/CamelProperties.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/routes/CamelProperties.java
@@ -1,0 +1,19 @@
+package io.hawt.tests.features.pageobjects.fragments.camel.tabs.routes;
+
+import static com.codeborne.selenide.Condition.exactText;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selectors.byXpath;
+import static com.codeborne.selenide.Selenide.$;
+import io.hawt.tests.features.pageobjects.pages.camel.CamelPage;
+
+/**
+ * Represents Properties Tab page in Camel.
+ */
+public class CamelProperties extends CamelPage {
+    public void checkDefaultQuartzProperties(String route, String autoStartup, String logMask, String delayer) {
+        $(byXpath("//dt[span[text()='Id']]/following-sibling::dd")).shouldBe(visible).shouldHave(exactText(route));
+        $(byXpath("//dt[span[text()='Auto Startup']]/following-sibling::dd")).shouldBe(visible).shouldHave(exactText(autoStartup));
+        $(byXpath("//dt[span[text()='Log Mask']]/following-sibling::dd")).shouldBe(visible).shouldHave(exactText(logMask));
+        $(byXpath("//dt[span[text()='Delayer']]/following-sibling::dd")).shouldBe(visible).shouldHave(exactText(delayer));
+    }
+}

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/camel/routes/CamelRoutesStepDefs.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/camel/routes/CamelRoutesStepDefs.java
@@ -4,6 +4,7 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.hawt.tests.features.config.TestConfiguration;
 import io.hawt.tests.features.pageobjects.fragments.camel.tabs.routes.CamelDebug;
+import io.hawt.tests.features.pageobjects.fragments.camel.tabs.routes.CamelProperties;
 import io.hawt.tests.features.pageobjects.fragments.camel.tabs.routes.CamelRouteDiagram;
 import io.hawt.tests.features.pageobjects.fragments.camel.tabs.routes.CamelRoutes;
 import io.hawt.tests.features.pageobjects.fragments.camel.tabs.routes.CamelSource;
@@ -14,6 +15,7 @@ public class CamelRoutesStepDefs {
     private final CamelRoutes camelRoutes = new CamelRoutes();
     private final CamelRouteDiagram camelRouteDiagram = new CamelRouteDiagram();
     private final CamelSource camelSource = new CamelSource();
+    private final CamelProperties camelProperties = new CamelProperties();
 
     @When("^User clicks on Delete button in dropdown in routes table$")
     public void userClicksOnDeleteButtonRoutesTable() {
@@ -35,6 +37,11 @@ public class CamelRoutesStepDefs {
     @Then("^Route source code is presented$")
     public void routeSourceCodeIsPresented() {
         camelSource.routeSourceCodeIsPresented();
+    }
+
+    @Then("^Default quartz properties of \"([^\"]*)\" are Auto Startup: \"([^\"]*)\", Log Mask: \"([^\"]*)\", Delayer: \"([^\"]*)\"$")
+    public void defaultQuartzPropertiesOfRouteAreAutoStartupLogMaskDelayer(String route, String autoStartup, String logMask, String delayer) {
+        camelProperties.checkDefaultQuartzProperties(route, autoStartup, logMask, delayer);
     }
 
     @When("^User adds breakpoint on \"([^\"]*)\" node$")

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/routes/camel_specific_route.feature
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/routes/camel_specific_route.feature
@@ -95,3 +95,9 @@ Feature: Checking the functionality of Camel Specific Route page.
     And User is on Camel "simple" item of "routes" folder of "SampleCamel" context
     When User clicks on Camel "Source" tab
     Then Route source code is presented
+
+  Scenario: Check Camel Properties tab is not empty
+    Given User is on "Camel" page
+    And User is on Camel "simple" item of "routes" folder of "SampleCamel" context
+    When User clicks on Camel "Properties" tab
+    Then Default quartz properties of "simple" are Auto Startup: "true", Log Mask: "false", Delayer: "advanced"


### PR DESCRIPTION
Add a new test scenario checking Camel Routes Properties tab.
In this specific scenario the quartz simple route properties are checked.