### PR TITLE
Remove redundant camel-quarkus-jaxb from Quarkus example project

### DIFF
--- a/examples/quarkus/pom.xml
+++ b/examples/quarkus/pom.xml
@@ -72,12 +72,6 @@
       <artifactId>camel-quarkus-management</artifactId>
     </dependency>
 
-    <!-- To enable Camel route dumping to XML. Required for the route diagram -->
-    <dependency>
-      <groupId>org.apache.camel.quarkus</groupId>
-      <artifactId>camel-quarkus-jaxb</artifactId>
-    </dependency>
-
     <!--
       To enable Camel plugin debugging feature, add this dependency.
     -->


### PR DESCRIPTION
Minor UX improvement.

`camel-quarkus-management` depends on `camel-quarkus-xml-jaxb`, which is enough for route dumping etc. In future CQ releases, the management extension will use the lightweight xml-io component, so it's probably best to clean up the example ahead of this.