### PR TITLE
feat(system): Support X-Jolokia-Authorization header (#3404)

### DIFF
--- a/hawtio-system/src/main/java/io/hawt/system/Authenticator.java
+++ b/hawtio-system/src/main/java/io/hawt/system/Authenticator.java
@@ -43,6 +43,7 @@ public class Authenticator {
     private static final Logger LOG = LoggerFactory.getLogger(Authenticator.class);
 
     public static final String HEADER_AUTHORIZATION = "Authorization";
+    public static final String X_J_HEADER_AUTHORIZATION = "X-Jolokia-Authorization";
     public static final String AUTHENTICATION_SCHEME_BASIC = "Basic";
     public static final String AUTHENTICATION_SCHEME_BEARER = "Bearer";
     public static final String ATTRIBUTE_X509_CERTIFICATE = "jakarta.servlet.request.X509Certificate";
@@ -94,7 +95,22 @@ public class Authenticator {
      * Callback is invoked only when Authorization header is present.
      */
     public static void extractAuthHeader(HttpServletRequest request, BiConsumer<String, String> callback) {
-        String authHeader = request.getHeader(Authenticator.HEADER_AUTHORIZATION);
+        extractAuthHeader(request, callback, false);
+    }
+
+    /**
+     * Extracts username/password from Authorization header.
+     * Callback is invoked only when Authorization header is present.
+     */
+    public static void extractAuthHeader(HttpServletRequest request, BiConsumer<String, String> callback,
+            boolean checkExtraHeaders) {
+        String authHeader = null;
+        if (checkExtraHeaders) {
+            authHeader = request.getHeader(X_J_HEADER_AUTHORIZATION);
+        }
+        if (Strings.isBlank(authHeader)) {
+            authHeader = request.getHeader(Authenticator.HEADER_AUTHORIZATION);
+        }
         if (Strings.isBlank(authHeader)) {
             return;
         }

--- a/hawtio-system/src/main/java/io/hawt/web/auth/AuthenticationConfiguration.java
+++ b/hawtio-system/src/main/java/io/hawt/web/auth/AuthenticationConfiguration.java
@@ -444,11 +444,12 @@ public class AuthenticationConfiguration {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private <T> Class<T> tryLoadClass(String roleClass, Class<T> clazz) {
         try {
             Class<?> cls = getClass().getClassLoader().loadClass(roleClass);
             if (clazz.isAssignableFrom(cls)) {
-                return clazz;
+                return (Class<T>) cls;
             } else {
                 LOG.warn("Class {} doesn't implement {}", cls, clazz);
             }

--- a/hawtio-system/src/main/java/io/hawt/web/auth/AuthenticationFilter.java
+++ b/hawtio-system/src/main/java/io/hawt/web/auth/AuthenticationFilter.java
@@ -85,9 +85,12 @@ public class AuthenticationFilter implements Filter {
         HttpSession session = httpRequest.getSession(false);
 
         if (proxyMode == ProxyRequestType.PROXY && session == null) {
-            // we reject proxy requests without session, because Authorization header is targeted at remote Jolokia
-            ServletHelpers.doForbidden(httpResponse, ForbiddenReason.SESSION_EXPIRED);
-            return;
+            if (!authConfiguration.isExternalAuthenticationEnabled()) {
+                // simple - we need a session, we don't have one
+                // we reject proxy requests without session, because Authorization header is targeted at remote Jolokia
+                ServletHelpers.doForbidden(httpResponse, ForbiddenReason.SESSION_EXPIRED);
+                return;
+            }
         }
 
         if (session != null) {

--- a/hawtio-system/src/main/java/io/hawt/web/auth/oidc/OidcLoginModule.java
+++ b/hawtio-system/src/main/java/io/hawt/web/auth/oidc/OidcLoginModule.java
@@ -178,6 +178,9 @@ public class OidcLoginModule implements LoginModule {
             oidcConfiguration.refreshPublicKeysIfNeeded();
             // context built on available signature public keys
             JWKSecurityContext jwkContext = oidcConfiguration.getJwkContext();
+            if (jwkContext == null) {
+                return null;
+            }
             DefaultJWTProcessor<JWKSecurityContext> processor = new DefaultJWTProcessor<>();
             processor.setJWSKeySelector(new KidKeySelector());
             DefaultJWTClaimsVerifier<JWKSecurityContext> claimsVerifier = new DefaultJWTClaimsVerifier<>(null, null, Set.of("sub"));

--- a/hawtio-system/src/main/java/io/hawt/web/proxy/ProxyDetails.java
+++ b/hawtio-system/src/main/java/io/hawt/web/proxy/ProxyDetails.java
@@ -40,7 +40,7 @@ public class ProxyDetails implements ProxyAddress {
         Authenticator.extractAuthHeader(httpServletRequest, (user, pass) -> {
             userName = user;
             password = pass;
-        });
+        }, true);
 
         // let's add the query parameters
         Enumeration<?> iter = httpServletRequest.getParameterNames();

--- a/platforms/quarkus/runtime/src/main/java/io/hawt/quarkus/filters/HawtioQuarkusAuthenticationFilter.java
+++ b/platforms/quarkus/runtime/src/main/java/io/hawt/quarkus/filters/HawtioQuarkusAuthenticationFilter.java
@@ -86,9 +86,12 @@ public class HawtioQuarkusAuthenticationFilter extends AuthenticationFilter {
         HttpSession session = httpRequest.getSession(false);
 
         if (proxyMode == ProxyRequestType.PROXY && session == null) {
-            // we reject proxy requests without session, because Authorization header is targeted at remote Jolokia
-            ServletHelpers.doForbidden(httpResponse, ForbiddenReason.SESSION_EXPIRED);
-            return;
+            if (!authConfiguration.isExternalAuthenticationEnabled()) {
+                // simple - we need a session, we don't have one
+                // we reject proxy requests without session, because Authorization header is targeted at remote Jolokia
+                ServletHelpers.doForbidden(httpResponse, ForbiddenReason.SESSION_EXPIRED);
+                return;
+            }
         }
 
         if (session != null) {


### PR DESCRIPTION
This is required when `Authorization` header carries a Bearer token for OIDC/Keycloak authentication, while we also have to pass credentials for remote Jolokia agent (accessible via "Connect" tab)