### PR TITLE
fix: HAWNG-851 Update RHBAC for Spring Boot version to 4.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,12 +55,12 @@
     <quarkus-version>3.8.4.SP1-redhat-00001</quarkus-version>
     <quarkus-extension-version>3.8.4.redhat-00002</quarkus-extension-version>
     <!-- Spring -->
-    <!-- https://docs.spring.io/spring-boot/docs/3.2.5/reference/html/dependency-versions.html -->
-    <spring-version>6.1.6</spring-version>
-    <spring-boot-version>3.2.5</spring-boot-version>
+    <!-- https://docs.spring.io/spring-boot/3.3.4/appendix/dependency-versions/coordinates.html -->
+    <spring-version>6.1.13</spring-version>
+    <spring-boot-version>3.3.4</spring-boot-version>
     <!-- Camel -->
     <!-- https://access.redhat.com/articles/7021827#headerCSB -->
-    <camel-spring-boot-version>4.4.0.redhat-00014</camel-spring-boot-version>
+    <camel-spring-boot-version>4.8.0.redhat-00010</camel-spring-boot-version>
     <!-- Jetty -->
     <jetty-version>11.0.20</jetty-version>
     <!-- Keycloak -->


### PR DESCRIPTION
With this, upstream E2E will no longer pass green until RHBAC for SB 4.8.0 version is released.