### PR TITLE
fix: For aligned version of quarkus, adds deprecated support for anno…

### DIFF
--- a/platforms/quarkus/runtime/pom.xml
+++ b/platforms/quarkus/runtime/pom.xml
@@ -110,6 +110,9 @@
               <version>${quarkus-extension-version}</version>
             </path>
           </annotationProcessorPaths>
+          <compilerArgs>
+	    <arg>-AlegacyConfigRoot=true</arg>
+	  </compilerArgs>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
…tations

* https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.14#getting-your-application-to-compile
 * Details change with compilation using ConfigRoot annotation
 * Without a ConfigMapping annotation, compile fails with aligned quarkus version
 * Adds in legacyConfigRoot property at this time to allow build

Note: this does not appear as a problem on compiling upstream - only on downstream builds.