### PR TITLE
chore(deps): upgrade to Quarkus 3.15.2 LTS

### DIFF
--- a/platforms/quarkus/deployment/pom.xml
+++ b/platforms/quarkus/deployment/pom.xml
@@ -71,6 +71,9 @@
               <version>${quarkus-version}</version>
             </path>
           </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-AlegacyConfigRoot=true</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/platforms/quarkus/deployment/src/test/java/io/hawt/quarkus/deployment/test/HawtioQuarkusAuthenticationDisabledTest.java
+++ b/platforms/quarkus/deployment/src/test/java/io/hawt/quarkus/deployment/test/HawtioQuarkusAuthenticationDisabledTest.java
@@ -6,7 +6,7 @@ import java.io.Writer;
 import java.util.List;
 import java.util.Properties;
 
-import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -23,7 +23,7 @@ public class HawtioQuarkusAuthenticationDisabledTest {
 
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-        .setForcedDependencies(List.of(new AppArtifact("io.hawt", "hawtio-quarkus-deployment", "4.3-SNAPSHOT")))
+        .setForcedDependencies(List.of(Dependency.of("io.hawt", "hawtio-quarkus-deployment", "4.3-SNAPSHOT")))
         .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
             .addAsResource(applicationProperties(), "application.properties"));

--- a/platforms/quarkus/deployment/src/test/java/io/hawt/quarkus/deployment/test/HawtioQuarkusAuthenticationEnabledTest.java
+++ b/platforms/quarkus/deployment/src/test/java/io/hawt/quarkus/deployment/test/HawtioQuarkusAuthenticationEnabledTest.java
@@ -6,7 +6,7 @@ import java.io.Writer;
 import java.util.List;
 import java.util.Properties;
 
-import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -23,7 +23,7 @@ public class HawtioQuarkusAuthenticationEnabledTest {
 
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-        .setForcedDependencies(List.of(new AppArtifact("io.hawt", "hawtio-quarkus-deployment", "4.3-SNAPSHOT")))
+        .setForcedDependencies(List.of(Dependency.of("io.hawt", "hawtio-quarkus-deployment", "4.3-SNAPSHOT")))
         .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
             .addAsResource(applicationProperties(), "application.properties"));

--- a/platforms/quarkus/deployment/src/test/java/io/hawt/quarkus/deployment/test/HawtioQuarkusPluginConfigurationTest.java
+++ b/platforms/quarkus/deployment/src/test/java/io/hawt/quarkus/deployment/test/HawtioQuarkusPluginConfigurationTest.java
@@ -6,7 +6,7 @@ import java.io.Writer;
 import java.util.List;
 import java.util.Properties;
 
-import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -23,7 +23,7 @@ public class HawtioQuarkusPluginConfigurationTest {
 
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-        .setForcedDependencies(List.of(new AppArtifact("io.hawt", "hawtio-quarkus-deployment", "4.3-SNAPSHOT")))
+        .setForcedDependencies(List.of(Dependency.of("io.hawt", "hawtio-quarkus-deployment", "4.3-SNAPSHOT")))
         .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
             .addAsResource(applicationProperties(), "application.properties"));

--- a/platforms/quarkus/runtime/pom.xml
+++ b/platforms/quarkus/runtime/pom.xml
@@ -110,6 +110,9 @@
               <version>${quarkus-version}</version>
             </path>
           </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-AlegacyConfigRoot=true</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <!-- Jolokia -->
     <jolokia-version>2.1.2</jolokia-version>
     <!-- Quarkus -->
-    <quarkus-version>3.12.1</quarkus-version>
+    <quarkus-version>3.15.2</quarkus-version>
     <!-- Spring -->
     <spring-version>6.1.13</spring-version>
     <spring-boot-version>3.3.4</spring-boot-version>


### PR DESCRIPTION
Added -AlegacyConfigRoot=true to keep legacy @ConfigRoot for Quarkus because the new @ConfigMapping has unresolvable issues #3704 at this moment.