### PR TITLE
e2e: add automated testing support for keycloak on quarkus

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -24,13 +24,12 @@ jobs:
     needs: build
     strategy:
       fail-fast: false
-      matrix: 
-        java: ['17', '21']
-        runtime: ['quarkus', 'springboot']
-#        browser: ['firefox', 'chrome']
-        browser: ['firefox'] # chrome disabled because of https://github.com/hawtio/hawtio-next/issues/478
+      matrix:
+        java: ["17", "21"]
+        runtime: ["quarkus", "springboot", "quarkus-keycloak"]
+        browser: ["firefox"] # chrome disabled because of https://github.com/hawtio/hawtio-next/issues/478
     env:
-      REPORT_DIR: results-${{matrix.runtime}}-${{matrix.java}}-${{matrix.browser}} 
+      REPORT_DIR: results-${{matrix.runtime}}-${{matrix.java}}-${{matrix.browser}}
     steps:
       - name: Docker Setup QEMU
         uses: docker/setup-qemu-action@v3.3.0
@@ -47,13 +46,19 @@ jobs:
       - name: ${{ matrix.runtime }} E2E test (Java ${{ matrix.java }})
         id: test
         run: |
+          runtime=${{matrix.runtime}}
+          extra_args=''
+          if [[ $runtime =~ "-keycloak" ]]; then
+            runtime=${runtime%-keycloak}
+            extra_args='-Dio.hawt.test.use.keycloak=true'
+          fi
           docker run --rm \
           -v /var/run/docker.sock:/var/run/docker.sock \
           -v $PWD/$REPORT_DIR:/hawtio-test-suite/tests/hawtio-test-suite/target \
           -v $PWD/$REPORT_DIR/build:/hawtio-test-suite/tests/hawtio-test-suite/build/ \
           --shm-size="2g" \
-          hawtio-test-suite:${{ matrix.java }} -Pe2e-${{ matrix.runtime }} -Dselenide.browser=${{ matrix.browser }} \
-          -Dio.hawt.test.docker.image=hawtio-${{ matrix.runtime }}-app:${{ matrix.java }}
+            hawtio-test-suite:${{ matrix.java }} -Pe2e-${runtime} -Dselenide.browser=${{ matrix.browser }} \
+            -Dio.hawt.test.docker.image=hawtio-${runtime}-app:${{ matrix.java }} $extra_args
       - name: Prepare report artifacts
         if: always()
         run: |
@@ -64,7 +69,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: 'test-results-${{ matrix.runtime }}-java-${{ matrix.java }}-${{ matrix.browser }}'
+          name: "test-results-${{ matrix.runtime }}-java-${{ matrix.java }}-${{ matrix.browser }}"
           path: |
             ${{ env.REPORT_DIR }}/build/reports/tests/*.png
             ${{ env.REPORT_DIR }}/*.log
@@ -75,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['17', '21']
+        java: ["17", "21"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -88,9 +93,9 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: ${{ matrix.java }}
-          cache: 'maven'
+          cache: "maven"
       - name: Docker Setup QEMU
         uses: docker/setup-qemu-action@v3.3.0
       - name: Build
@@ -123,14 +128,14 @@ jobs:
         uses: actions/upload-artifact/merge@v4
         if: always()
         with:
-          name: 'test-results'
+          name: "test-results"
           pattern: test-results-*
           separate-directories: true
       - name: Download Test Results
         uses: actions/download-artifact@v4
-        with: 
-          name: 'test-results'
-          path: 'test-results'
+        with:
+          name: "test-results"
+          path: "test-results"
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/examples/keycloak-integration/hawtio-demo-realm.json
+++ b/examples/keycloak-integration/hawtio-demo-realm.json
@@ -2,6 +2,7 @@
   "realm": "hawtio-demo",
   "registrationAllowed": true,
   "enabled": true,
+  "sslRequired": "none",
   "clients": [
     {
       "clientId": "hawtio-client",

--- a/tests/hawtio-test-suite/pom.xml
+++ b/tests/hawtio-test-suite/pom.xml
@@ -198,6 +198,12 @@
       <version>2.0.1.Final</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.dasniko</groupId>
+      <artifactId>testcontainers-keycloak</artifactId>
+      <version>3.4.0</version>
+    </dependency>
+
   </dependencies>
 
   <profiles>

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/config/TestConfiguration.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/config/TestConfiguration.java
@@ -25,6 +25,8 @@ public class TestConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(TestConfiguration.class);
 
     public static final String RUNTIME = "io.hawt.test.runtime";
+    public static final String USE_KEYCLOAK = "io.hawt.test.use.keycloak";
+    public static final String KEYCLOAK_IMAGE = "io.hawt.test.keycloak.image";
     public static final String APP_DOCKER_IMAGE = "io.hawt.test.docker.image";
     public static final String APP_PATH = "io.hawt.test.app.path";
     public static final String APP_URL = "io.hawt.test.url";
@@ -127,6 +129,14 @@ public class TestConfiguration {
             }
         }
         return null;
+    }
+
+    public static boolean useKeycloak() {
+        return getBoolean(USE_KEYCLOAK, false);
+    }
+
+    public static String getKeycloakImage() {
+        return getProperty(KEYCLOAK_IMAGE, "quay.io/keycloak/keycloak");
     }
 
     public static String getHawtioOnlineImageRepository() {

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/hooks/DeployAppHook.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/hooks/DeployAppHook.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import io.cucumber.java.Before;
 import io.hawt.tests.features.config.TestConfiguration;
 import io.hawt.tests.features.setup.deployment.AppDeployment;
+import io.hawt.tests.features.setup.deployment.KeycloakDeployment;
 
 public class DeployAppHook {
 
@@ -35,6 +36,10 @@ public class DeployAppHook {
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 LOG.info("Cleaning up");
                 app.stop();
+
+                if (TestConfiguration.useKeycloak()) {
+                    KeycloakDeployment.stop();
+                }
             }));
         } catch (Throwable e) {
             startupFailure = e;

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/hooks/SkipTestsHook.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/hooks/SkipTestsHook.java
@@ -37,8 +37,16 @@ public class SkipTestsHook {
         Assumptions.assumeTrue(TestConfiguration.getAppDeploymentMethod() instanceof OpenshiftDeployment);
     }
 
+    @Before("@notKeycloak")
+    public void skipKeycloakTests() {
+        Assumptions.assumeFalse(TestConfiguration.useKeycloak());
+    }
+
     @After("@throttling")
     public void afterThrottling() {
+        if (TestConfiguration.useKeycloak()) {
+            return;
+        }
         while (WebDriverRunner.getWebDriver().getWindowHandles().size() != 1) {
             Selenide.closeWindow();
             Selenide.switchTo().window(0);

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/WebDriver.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/WebDriver.java
@@ -39,6 +39,8 @@ public class WebDriver {
         } else {
             FirefoxOptions options = new FirefoxOptions();
             options.addPreference("network.proxy.allow_hijacking_localhost", false);
+            //Trust the docker internal network
+            options.addPreference("dom.securecontext.allowlist", "172.17.0.1");
             Configuration.browserCapabilities = options;
         }
         Configuration.headless = TestConfiguration.browserHeadless();

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/deployment/KeycloakDeployment.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/deployment/KeycloakDeployment.java
@@ -1,0 +1,34 @@
+package io.hawt.tests.features.setup.deployment;
+
+import org.keycloak.admin.client.Keycloak;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.hawt.tests.features.config.TestConfiguration;
+
+public class KeycloakDeployment {
+
+    private static KeycloakContainer container = new KeycloakContainer(TestConfiguration.getKeycloakImage())
+        .withRealmImportFile("keycloak-demo-realm.json");
+
+    public static void start() {
+        container.start();
+    }
+
+    public static void stop() {
+        if (container.isRunning()) {
+            container.stop();
+        }
+    }
+
+    public static String getIssuerURL() {
+        return container.getAuthServerUrl() + "/realms/hawtio-demo";
+    }
+
+    public static Keycloak adminClient() {
+        return container.getKeycloakAdminClient();
+    }
+
+    public static String getURL() {
+        return container.getAuthServerUrl();
+    }
+}

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/deployment/MavenDeployment.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/deployment/MavenDeployment.java
@@ -2,15 +2,23 @@ package io.hawt.tests.features.setup.deployment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,10 +27,13 @@ import java.util.Optional;
 import java.util.Properties;
 
 import io.hawt.tests.features.config.TestConfiguration;
+import io.hawt.tests.features.utils.TestUtils;
 
 public class MavenDeployment implements AppDeployment {
 
     private static final String DEFAULT_PORT = "8080";
+
+    private static final String QUARKUS_KEYCLOAK_FILE = ".quarkus-uses-keycloak";
 
     private final String path;
 
@@ -49,10 +60,10 @@ public class MavenDeployment implements AppDeployment {
             final File classesFolder = path.resolve("classes").resolve("application.properties").toFile();
 
             final Properties properties = new Properties();
-            try {
-                properties.load(new FileInputStream(classesFolder));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+            TestUtils.tryOrRuntimeException(() -> properties.load(new FileInputStream(classesFolder)), "Failed to load properties");
+
+            if (TestConfiguration.useKeycloak()) {
+                KeycloakDeployment.start();
             }
 
             //find quarkus or springboot app and run
@@ -61,9 +72,15 @@ public class MavenDeployment implements AppDeployment {
                     Arrays.stream(file.list()).filter(it -> it.endsWith(".jar")).filter(it -> !it.contains("sources")).findFirst();
                 assertThat(jarName).describedAs("Expecting Springboot JAR to exist").isPresent();
 
-                cmd.add(Path.of(file.getAbsolutePath(), jarName.get()).toString());
+                final Path jarPath = Path.of(file.getAbsolutePath(), jarName.get());
+                cmd.add(jarPath.toString());
 
                 port = properties.getProperty("management.server.port", properties.getProperty("server.port", DEFAULT_PORT));
+                if (TestConfiguration.useKeycloak()) {
+                    modifyKeycloakJsonFile(jarPath);
+                    cmd.add("--spring.profiles.active=keycloak");
+                    cmd.add("--keycloak-url=" + KeycloakDeployment.getIssuerURL());
+                }
             } else if (TestConfiguration.isQuarkus()) {
                 final Path quarkusFolder = path.resolve("quarkus-app");
                 assertThat(quarkusFolder).exists();
@@ -73,6 +90,31 @@ public class MavenDeployment implements AppDeployment {
                 cmd.add(quarkusRun.toString());
 
                 port = properties.getProperty("quarkus.http.port", DEFAULT_PORT);
+
+                boolean quarkusUsesKeycloak = quarkusFolder.resolve(QUARKUS_KEYCLOAK_FILE).toFile().exists();
+
+                if (TestConfiguration.useKeycloak()) {
+                    if (!quarkusUsesKeycloak) {
+                        List<String> rebuildCmd = new ArrayList<>(cmd);
+                        rebuildCmd.add(1, "-Dquarkus.launch.rebuild=true");
+                        rebuildCmd.add(1, "-Dquarkus.profile=keycloak");
+
+                        TestUtils.runCmd(rebuildCmd, new File("target", "rebuild.log"));
+
+                        TestUtils.tryOrRuntimeException(() -> FileUtils.write(quarkusFolder.resolve(QUARKUS_KEYCLOAK_FILE).toFile(), "", Charset.defaultCharset()), "Failed to create a file");
+                    }
+                    final Path appFolder = quarkusFolder.resolve("app");
+
+                    modifyKeycloakJsonFile(appFolder.resolve(appFolder.toFile().list()[0]));
+                    cmd.add(1, "-Dquarkus.oidc.auth-server-url=" + KeycloakDeployment.getIssuerURL());
+                } else {
+                    if (quarkusUsesKeycloak) {
+                        List<String> rebuildCmd = new ArrayList<>(cmd);
+                        rebuildCmd.add(1, "-Dquarkus.launch.rebuild=true");
+                        TestUtils.runCmd(rebuildCmd, new File("target", "rebuild.log"));
+                        TestUtils.tryOrRuntimeException(() -> FileUtils.delete(quarkusFolder.resolve(QUARKUS_KEYCLOAK_FILE).toFile()), "Failed to delete a file");
+                    }
+                }
             } else {
                 throw new RuntimeException("Invalid runtime chosen");
             }
@@ -87,6 +129,24 @@ public class MavenDeployment implements AppDeployment {
             assertThat(process.isAlive()).isTrue();
             waitForAppRunning();
         } catch (IOException | ConditionTimeoutException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void modifyKeycloakJsonFile(Path jarPath) {
+        try (FileSystem fs = FileSystems.newFileSystem(jarPath, (ClassLoader) null)) {
+            Path keycloakFile;
+            if (TestConfiguration.isQuarkus()) {
+                keycloakFile = fs.getPath("keycloak-hawtio.json");
+            } else {
+                keycloakFile = fs.getPath("BOOT-INF", "classes", "hawtio-static", "keycloak-hawtio.json");
+            }
+            String content = Files.readString(keycloakFile);
+
+            final JsonElement json = JsonParser.parseString(content);
+            json.getAsJsonObject().addProperty("url", KeycloakDeployment.getURL());
+            Files.writeString(keycloakFile, json.toString(), StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/utils/TestUtils.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/utils/TestUtils.java
@@ -1,0 +1,30 @@
+package io.hawt.tests.features.utils;
+
+import org.junit.function.ThrowingRunnable;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+public class TestUtils {
+    public static void runCmd(List<String> cmd, File outputLog) {
+        try {
+            Process rebuildProcess =
+                new ProcessBuilder(cmd).redirectOutput(outputLog).redirectErrorStream(true).start();
+            int ret = rebuildProcess.waitFor();
+            if (ret != 0) {
+                throw new RuntimeException("Quarkus app failed to rebuild");
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void tryOrRuntimeException(ThrowingRunnable runnable, String message) {
+        try {
+            runnable.run();
+        } catch (Throwable e) {
+            throw new RuntimeException(message, e);
+        }
+    }
+}

--- a/tests/hawtio-test-suite/src/main/resources/keycloak-demo-realm.json
+++ b/tests/hawtio-test-suite/src/main/resources/keycloak-demo-realm.json
@@ -1,0 +1,104 @@
+{
+  "realm": "hawtio-demo",
+  "registrationAllowed": true,
+  "enabled": true,
+  "sslRequired": "none",
+  "clients": [
+    {
+      "clientId": "hawtio-client",
+      "enabled": true,
+      "redirectUris": [
+        "http://localhost:8080/*",
+        "http://localhost:8181/*",
+        "http://localhost:10000/*",
+        "http://localhost:10001/*",
+        "http://0.0.0.0:8080/*",
+        "http://0.0.0.0:8181/*",
+        "http://0.0.0.0:10000/*",
+        "http://0.0.0.0:10001/*",
+        "*"
+      ],
+      "webOrigins": ["+", "*"],
+      "bearerOnly": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "publicClient": true,
+      "attributes": {
+        "pkce.code.challenge.method": ""
+      }
+    }
+  ],
+  "users": [
+    {
+      "username": "admin",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "firstName": "Admin",
+      "lastName": "Hawtio",
+      "email": "admin@hawt.io",
+      "credentials": [
+        {
+          "type": "password",
+          "hashedSaltedValue": "lVKP+Q9eCLjfaPQs1581XFphVHHbrI5dsnFYa4sYxzP2ZT9mdPCNOKGK9yts3NYrgr1jgGdu/gtSqXh/PxWvwA==",
+          "salt": "uysYXjMukx9lNodzEuw/qw==",
+          "hashIterations": 27500,
+          "algorithm": "pbkdf2-sha256",
+          "temporary": false
+        }
+      ],
+      "requiredActions": [],
+      "realmRoles": ["user", "viewer", "manager", "admin"],
+      "clientRoles": {
+        "account": ["view-profile", "manage-account"]
+      }
+    },
+    {
+      "username": "viewer",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "firstName": "Viewer",
+      "lastName": "Hawtio",
+      "email": "viewer@hawt.io",
+      "credentials": [
+        {
+          "type": "password",
+          "hashedSaltedValue": "oU80vldSnPVT17jNoQX2tQQxZ+VToIcz6Ea6y5irQbIPsCYkRvKOvoJ2BthGr95AXsNs/lIFjXUswqe4pa24PA==",
+          "salt": "x8MOfkM/ynakMcCVBUXQDA==",
+          "hashIterations": 27500,
+          "algorithm": "pbkdf2-sha256",
+          "temporary": false
+        }
+      ],
+      "requiredActions": [],
+      "realmRoles": ["user", "viewer"],
+      "clientRoles": {
+        "account": ["view-profile", "manage-account"]
+      }
+    },
+    {
+      "username": "jdoe",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "firstName": "John",
+      "lastName": "Doe",
+      "email": "jdoe@acme.com",
+      "credentials": [
+        {
+          "type": "password",
+          "hashedSaltedValue": "ltSl89y75f8LTzoT646xO9NPTrm114ubTauplgw+TQ62ZDy8K89+y7jFzp/jnSvEh9TENQ4RRvNA6vdGOUDcXg==",
+          "salt": "m8PY6Q9lICl9BHSS03D2Ug==",
+          "hashIterations": 1,
+          "temporary": false
+        }
+      ],
+      "requiredActions": [],
+      "realmRoles": ["user"],
+      "clientRoles": {
+        "account": ["view-profile", "manage-account"]
+      }
+    }
+  ]
+}

--- a/tests/hawtio-test-suite/src/main/resources/logback-test.xml
+++ b/tests/hawtio-test-suite/src/main/resources/logback-test.xml
@@ -32,6 +32,7 @@
   <logger name="hawtio-app">
     <appender-ref ref="container-logger"/>
   </logger>
+  <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
   <appender class="ch.qos.logback.core.FileAppender" name="container-logger">
   	<file>target/hawtio-app.log</file>
     <encoder>

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/security/throttling.feature
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/security/throttling.feature
@@ -1,4 +1,4 @@
-@throttling @notOnline
+@throttling @notOnline @notKeycloak
 Feature: Account Lockout (Throttling)
 
   Scenario: User account gets locked out after multiple failed login attempts

--- a/tests/quarkus/.dockerignore
+++ b/tests/quarkus/.dockerignore
@@ -1,4 +1,3 @@
-*
 !target/*-runner
 !target/*-runner.jar
 !target/lib/*

--- a/tests/quarkus/pom.xml
+++ b/tests/quarkus/pom.xml
@@ -114,6 +114,10 @@
       <artifactId>hawtio-quarkus</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-oidc</artifactId>
+    </dependency>
     <!--
       Hawtio example plugin project
       Since static resources are packaged under META-INF/resources in the JAR,

--- a/tests/quarkus/src/main/docker/Dockerfile.jvm
+++ b/tests/quarkus/src/main/docker/Dockerfile.jvm
@@ -87,6 +87,10 @@ COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/
 COPY --chown=185 target/quarkus-app/*.jar /deployments/
 COPY --chown=185 target/quarkus-app/app/ /deployments/app/
 COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --chown=185 ./start-keycloak.sh /deployments/
+
+#Needed for quarkus rebuild inside container for some reason
+RUN ln -s /deployments/ /quarkus-app && chmod a+rw /quarkus-app
 
 EXPOSE 8080
 USER 185

--- a/tests/quarkus/src/main/resources/application-keycloak.properties
+++ b/tests/quarkus/src/main/resources/application-keycloak.properties
@@ -1,0 +1,20 @@
+quarkus.hawtio.keycloakEnabled = true
+quarkus.hawtio.keycloakClientConfig = classpath:keycloak-hawtio.json
+
+# Uncomment to enable user role checks
+#quarkus.hawtio.roles = admin
+
+#
+# Quarkus OIDC configuration for Keycloak
+#
+quarkus.oidc.enabled=true
+#quarkus.oidc.auth-server-url = http://localhost:18080/realms/hawtio-demo
+quarkus.oidc.client-id = hawtio-client
+quarkus.oidc.credentials.secret = secret
+quarkus.oidc.application-type = web-app
+quarkus.oidc.token-state-manager.split-tokens = true
+quarkus.http.auth.permission.authenticated.paths = /*
+quarkus.http.auth.permission.authenticated.policy = authenticated
+quarkus.security.users.embedded.enabled = false
+
+quarkus.keycloak.devservices.enabled=false

--- a/tests/quarkus/src/main/resources/application.properties
+++ b/tests/quarkus/src/main/resources/application.properties
@@ -42,3 +42,6 @@ camel.context.name = SampleCamel
 
 quartz.cron = 0/10 * * * * ?
 quartz.repeatInterval = 10000
+
+quarkus.oidc.enabled=false
+quarkus.package.jar.type=mutable-jar

--- a/tests/quarkus/src/main/resources/keycloak-hawtio.json
+++ b/tests/quarkus/src/main/resources/keycloak-hawtio.json
@@ -1,0 +1,6 @@
+{
+  "realm": "hawtio-demo",
+  "clientId": "hawtio-client",
+  "url": "http://localhost:18080/",
+  "jaas": false
+}

--- a/tests/quarkus/start-keycloak.sh
+++ b/tests/quarkus/start-keycloak.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+cd /tmp
+jar xf /deployments/app/*.jar keycloak-hawtio.json
+sed -i s,http://localhost:18080,$KEYCLOAK_URL, keycloak-hawtio.json
+jar uf  /deployments/app/*.jar keycloak-hawtio.json
+java -Dquarkus.profile=keycloak -Dquarkus.launch.rebuild=true -jar ${JAVA_APP_JAR}
+echo "Running: java -jar ${JAVA_OPTS} -Dquarkus.oidc.auth-server-url=$KEYCLOAK_URL/realms/hawtio-demo ${JAVA_APP_JAR}"
+java -jar ${JAVA_OPTS} -Dquarkus.oidc.auth-server-url=$KEYCLOAK_URL/realms/hawtio-demo ${JAVA_APP_JAR}

--- a/tests/springboot/pom.xml
+++ b/tests/springboot/pom.xml
@@ -174,6 +174,14 @@
       <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-client</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tests/springboot/src/main/java/io/hawt/tests/spring/boot/ApplicationNoSecurity.java
+++ b/tests/springboot/src/main/java/io/hawt/tests/spring/boot/ApplicationNoSecurity.java
@@ -1,0 +1,16 @@
+package io.hawt.tests.spring.boot;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+
+@Configuration
+@Profile("!keycloak")
+public class ApplicationNoSecurity {
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring().anyRequest();
+    }
+}

--- a/tests/springboot/src/main/resources/application-keycloak.properties
+++ b/tests/springboot/src/main/resources/application-keycloak.properties
@@ -1,0 +1,15 @@
+#
+# Hawtio Keycloak configuration
+#
+hawtio.authenticationEnabled = true
+hawtio.keycloakEnabled = true
+hawtio.keycloakClientConfig = classpath:keycloak-hawtio.json
+
+#
+# Spring Security OAuth2 configuration for Keycloak
+#
+spring.security.oauth2.client.provider.keycloak.issuer-uri = ${keycloak-url}
+spring.security.oauth2.client.registration.keycloak.client-id = hawtio-client
+spring.security.oauth2.client.registration.keycloak.authorization-grant-type = authorization_code
+spring.security.oauth2.client.registration.keycloak.scope = openid
+spring.autoconfigure.include=org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration

--- a/tests/springboot/src/main/resources/application.properties
+++ b/tests/springboot/src/main/resources/application.properties
@@ -29,10 +29,8 @@ camel.springboot.name=SampleCamel
 
 quartz.cron = 0/10 * * * * ?
 quartz.repeatInterval = 10000
-
 hawtio.authenticationEnabled=false
 
-#
 # Hawtio properties to change the behaviours for HTTP headers
 # (Hawtio version >2.15.1)
 #

--- a/tests/springboot/src/main/resources/hawtio-static/keycloak-hawtio.json
+++ b/tests/springboot/src/main/resources/hawtio-static/keycloak-hawtio.json
@@ -1,0 +1,6 @@
+{
+  "realm": "hawtio-demo",
+  "clientId": "hawtio-client",
+  "url": "http://localhost:18080/",
+  "jaas": false
+}


### PR DESCRIPTION
See passing runs: https://github.com/mmuzikar/hawtio/actions/runs/13110882131
Runs the standard testsuite using admin account on keycloak.