### PR TITLE
[E2E] Fix Camel messaging tests and Camel Source view code test

### DIFF
--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/endpoints/CamelSend.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/endpoints/CamelSend.java
@@ -4,8 +4,8 @@ import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byAttribute;
 import static com.codeborne.selenide.Selectors.byTagAndText;
-import static com.codeborne.selenide.Selectors.byXpath;
 import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.actions;
 import io.hawt.tests.features.pageobjects.pages.camel.CamelPage;
 
 
@@ -33,7 +33,9 @@ public class CamelSend extends CamelPage {
      * @param message body content
      */
     public void addMessageBody(String message) {
-        $(byXpath("//textarea")).sendKeys(message);
+        // .sendKeys() work directly only with interactable inputs and textareas
+        $("div.view-line").click();
+        actions().moveToElement($("div.view-line span span")).sendKeys(message).perform();
     }
 
     /**

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/routes/CamelSource.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/routes/CamelSource.java
@@ -9,6 +9,6 @@ import io.hawt.tests.features.pageobjects.pages.camel.CamelPage;
  */
 public class CamelSource extends CamelPage {
     public void routeSourceCodeIsPresented() {
-        $$(".view-line span").shouldHave(sizeGreaterThanOrEqual(1));
+        $$("div.view-line").shouldHave(sizeGreaterThanOrEqual(1));
     }
 }


### PR DESCRIPTION
In this PR:

- Fixed Camel Endpoints messaging tests (Send, Browse, etc.);
- Fixed Camel Routes Source tests to view a code;

The failures were causing because of replacing textarea by span elements wrapped inside div elements.