### PR TITLE
Remove deprecated Pragma header

### DIFF
--- a/hawtio-system/src/main/java/io/hawt/web/filters/CacheHeadersFilter.java
+++ b/hawtio-system/src/main/java/io/hawt/web/filters/CacheHeadersFilter.java
@@ -27,7 +27,6 @@ public class CacheHeadersFilter extends HttpHeaderFilter {
         throws IOException {
         if (!cacheInBrowser(request)) {
             response.setHeader("Cache-Control", "max-age=0, no-cache, must-revalidate, proxy-revalidate, private");
-            response.setHeader("Pragma", "no-cache");
         }
     }
 


### PR DESCRIPTION
Pragma header is deprecated - Cache-Control is enough.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Pragma