### PR TITLE
chore(deps): update jetty servlet api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <mockito-core-version>5.16.1</mockito-core-version>
     <nimbusds-jose-version>10.0.2</nimbusds-jose-version>
     <picocli-version>4.7.7</picocli-version>
-    <servlet-api-version>5.0.0</servlet-api-version>
+    <servlet-api-version>6.1.0</servlet-api-version>
     <!-- Pin SLF4J version until https://issues.apache.org/jira/browse/CAMEL-20598 is resolved at SLF4J -->
     <slf4j-version>2.0.11</slf4j-version>
 


### PR DESCRIPTION
Bumps servlet-api, jetty 12 supports v6.x.
v5.0.0 was compiled with java 1.8, and v6.1.0 with java 11.