### PR TITLE
[E2E] Add grouped routes, refactor existing and add new tests.

### DIFF
--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/Table.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/Table.java
@@ -4,6 +4,7 @@ import static com.codeborne.selenide.CollectionCondition.containExactTextsCaseSe
 import static com.codeborne.selenide.CollectionCondition.exactTextsCaseSensitive;
 import static com.codeborne.selenide.CollectionCondition.sizeGreaterThanOrEqual;
 import static com.codeborne.selenide.Condition.attribute;
+import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Condition.interactable;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byTagAndText;
@@ -76,6 +77,16 @@ public class Table {
      */
     public void checkColumnIsNotEmpty(String headerName) {
         getColumn(headerName).shouldBe(sizeGreaterThanOrEqual(1));
+    }
+
+    /**
+     * Check that column contains the value.
+     *
+     * @param headerName of the column to be checked
+     * @param value to be checked if it is under the column
+     */
+    public void checkColumnHasValue(String headerName, String value) {
+        getColumn(headerName).findBy(exactText(value)).shouldBe(visible);
     }
 
     /**

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/camel/CamelTableStepDefs.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/camel/CamelTableStepDefs.java
@@ -18,6 +18,11 @@ public class CamelTableStepDefs {
         table.checkColumnIsNotEmpty(column);
     }
 
+    @Then("^Camel table \"([^\"]*)\" column has \"([^\"]*)\" value$")
+    public void camelTableColumnHasValue(String column, String value) {
+        table.checkColumnHasValue(column, value);
+    }
+
     @Then("^Camel table has \"([^\"]*)\" key and \"([^\"]*)\" value$")
     public void camelTableHasKeyAndValue(String key, String value) {
         table.checkKeyAndValuePairs(key, value);

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/camel/CamelTreeStepDefs.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/camel/CamelTreeStepDefs.java
@@ -38,6 +38,15 @@ public class CamelTreeStepDefs {
             .selectSpecificItem(folder(context) + "-" + folder(folder) + "-" + item);
     }
 
+    @And("^User is on Camel \"([^\"]*)\" item of \"([^\"]*)\" group of \"([^\"]*)\" folder of \"([^\"]*)\" context$")
+    public void userIsOnCamelItemOfGroupOfFolderOfContext(String item, String group, String folder, String context) {
+        camelPage.tree()
+            .expandSpecificFolder(Tree.class, folder(context))
+            .expandSpecificFolder(Tree.class, folder(context) + "-" + folder(folder))
+            .expandSpecificFolder(Tree.class, folder(context) + "-" + folder(folder) + "-" + folder(group))
+            .selectSpecificItem(folder(context) + "-" + folder(folder) + "-" + folder(group) + "-" + item);
+    }
+
     @When("^User expands Camel tree$")
     public void userExpandsCamelTree() {
         camelPage.tree().expandTree();

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/contexts/camel_specific_context.feature
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/contexts/camel_specific_context.feature
@@ -31,7 +31,7 @@ Feature: Checking the functionality of a specific camel context page.
     And User is on Camel "SampleCamel" context
     When User clicks on Camel "Operations" tab
     When User executes operation with name "getTotalRoutes()"
-    Then Result of "getTotalRoutes()" operation is "2"
+    Then Result of "getTotalRoutes()" operation is "6"
 
   Scenario: Check to view and edit chart of Specific Context
     Given User is on "Camel" page
@@ -41,7 +41,7 @@ Feature: Checking the functionality of a specific camel context page.
     And User unwatch all "SampleCamel" attributes
     And User watches "TotalRoutes" attribute
     And User closes Edit watches mode of Camel Chart
-    Then Camel Attribute "TotalRoutes" and its value "2" are displayed in Camel Chart
+    Then Camel Attribute "TotalRoutes" and its value "6" are displayed in Camel Chart
     And Camel Attribute "ExchangesFailed" is not displayed in Camel Chart
 
   Scenario: Check the suspend action with Camel Specific Context.

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/routes/camel_routes.feature
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/routes/camel_routes.feature
@@ -8,9 +8,13 @@ Feature: Checking the functionality of Camel Routes page.
     And Camel table has "<name>" key and "<state>" value
 
     Examples: Columns
-      | column | name   | state   |
-      | Name   | cron   | Started |
-      | State  | simple | Started |
+      | column    | name           | state   |
+      | Name      | cron           | Started |
+      | State     | simple         | Started |
+      | Uptime    | interval1Route | Started |
+      | Completed | interval2Route | Started |
+      | Failed    | subject1Route  | Started |
+      | Total     | subject2Route  | Started |
 
   Scenario: Check that route nodes do not overlay
     Given User is on "Camel" page
@@ -38,6 +42,18 @@ Feature: Checking the functionality of Camel Routes page.
       | action | initial state | desired state |
       | Stop   | Started       | Stopped       |
       | Start  | Stopped       | Started       |
+
+  Scenario Outline: Check route groups
+    Given User is on "Camel" page
+    When User is on Camel "<group>" item of "routes" folder of "SampleCamel" context
+    Then Camel table "MBean" column has "<route1>" value
+    And Camel table "MBean" column has "<route2>" value
+
+    Examples: Groups
+      | group     | route1         | route2         |
+      | default   | cron           | simple         |
+      | intervals | interval1Route | interval2Route |
+      | subjects  | subject1Route  | subject2Route  |
 
   Scenario: Check the delete operation on Camel route
     Given User is on "Camel" page

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/routes/camel_specific_route.feature
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/routes/camel_specific_route.feature
@@ -2,7 +2,7 @@ Feature: Checking the functionality of Camel Specific Route page.
 
   Scenario Outline: Check that Camel Route diagram is presented
     Given User is on "Camel" page
-    And User is on Camel "simple" item of "routes" folder of "SampleCamel" context
+    And User is on Camel "simple" item of "default" group of "routes" folder of "SampleCamel" context
     When User clicks on Camel "Attributes" tab
     Then Camel table "<column>" column is not empty
     And Camel table has "<attribute>" key and "<value>" value
@@ -14,7 +14,7 @@ Feature: Checking the functionality of Camel Specific Route page.
 
   Scenario Outline: Check the Camel attributes are sorted correctly
     Given User is on "Camel" page
-    And User is on Camel "mock" item of "components" folder of "SampleCamel" context
+    And User is on Camel "simple" item of "default" group of "routes" folder of "SampleCamel" context
     When User clicks on Camel "Attributes" tab
     Then Attributes table is sorted "<desiredOrder>" by "<headerName>"
 
@@ -25,21 +25,21 @@ Feature: Checking the functionality of Camel Specific Route page.
 
   Scenario: Check specific endpoint attribute's detail information
     Given User is on "Camel" page
-    And User is on Camel "simple" item of "routes" folder of "SampleCamel" context
+    And User is on Camel "simple" item of "default" group of "routes" folder of "SampleCamel" context
     And User clicks on Camel "Attributes" tab
     When User expands Attribute details with the name "RouteId"
     Then Camel Attribute details have "Value" key and "simple" value
 
   Scenario: Check to execute operation of Specific Endpoint
     Given User is on "Camel" page
-    And User is on Camel "simple" item of "routes" folder of "SampleCamel" context
+    And User is on Camel "simple" item of "default" group of "routes" folder of "SampleCamel" context
     And User clicks on Camel "Operations" tab
     When User executes operation with name "getRouteId()"
     Then Result of "getRouteId()" operation is "simple"
 
   Scenario: Check to view and edit chart of Specific Context
     Given User is on "Camel" page
-    And User is on Camel "simple" item of "routes" folder of "SampleCamel" context
+    And User is on Camel "simple" item of "default" group of "routes" folder of "SampleCamel" context
     When User clicks on Camel "Operations" tab
     And User executes operation with name "getMaxProcessingTime()"
     And The result of the "getMaxProcessingTime()" operation is stored
@@ -54,7 +54,7 @@ Feature: Checking the functionality of Camel Specific Route page.
   @quarkus
   Scenario: Check to start the debugging
     Given User is on "Camel" page
-    And User is on Camel "simple" item of "routes" folder of "SampleCamel" context
+    And User is on Camel "simple" item of "default" group of "routes" folder of "SampleCamel" context
     And User clicks on Camel "Debug" tab
     And Start debugging option is presented
     When User starts debugging
@@ -62,7 +62,7 @@ Feature: Checking the functionality of Camel Specific Route page.
 
   Scenario: Check to add a breakpoint while debugging
     Given User is on "Camel" page
-    And User is on Camel "simple" item of "routes" folder of "SampleCamel" context
+    And User is on Camel "simple" item of "default" group of "routes" folder of "SampleCamel" context
     And User clicks on Camel "Debug" tab
     And Debugging is started
     When User adds breakpoint on "To stream" node
@@ -70,7 +70,7 @@ Feature: Checking the functionality of Camel Specific Route page.
 
   Scenario: Check to remove a breakpoint while debugging
     Given User is on "Camel" page
-    And User is on Camel "simple" item of "routes" folder of "SampleCamel" context
+    And User is on Camel "simple" item of "default" group of "routes" folder of "SampleCamel" context
     And User clicks on Camel "Debug" tab
     And Debugging is started
     When User removes breakpoint on "To stream" node
@@ -78,7 +78,7 @@ Feature: Checking the functionality of Camel Specific Route page.
 
   Scenario: Check to stop the debugging
     Given User is on "Camel" page
-    And User is on Camel "simple" item of "routes" folder of "SampleCamel" context
+    And User is on Camel "simple" item of "default" group of "routes" folder of "SampleCamel" context
     And User clicks on Camel "Debug" tab
     And Debugging is started
     When User stops debugging
@@ -86,18 +86,18 @@ Feature: Checking the functionality of Camel Specific Route page.
 
   Scenario: Check that Camel Route diagram is presented
     Given User is on "Camel" page
-    And User is on Camel "simple" item of "routes" folder of "SampleCamel" context
+    And User is on Camel "simple" item of "default" group of "routes" folder of "SampleCamel" context
     When User clicks on Camel "Route Diagram" tab
     Then Camel Route diagram is presented
 
   Scenario: Check that Camel Source is not empty
     Given User is on "Camel" page
-    And User is on Camel "simple" item of "routes" folder of "SampleCamel" context
+    And User is on Camel "simple" item of "default" group of "routes" folder of "SampleCamel" context
     When User clicks on Camel "Source" tab
     Then Route source code is presented
 
   Scenario: Check Camel Properties tab is not empty
     Given User is on "Camel" page
-    And User is on Camel "simple" item of "routes" folder of "SampleCamel" context
+    And User is on Camel "simple" item of "default" group of "routes" folder of "SampleCamel" context
     When User clicks on Camel "Properties" tab
     Then Default quartz properties of "simple" are Auto Startup: "true", Log Mask: "false", Delayer: "advanced"

--- a/tests/quarkus/src/main/java/io/hawt/tests/quarkus/SampleCamelRoute.java
+++ b/tests/quarkus/src/main/java/io/hawt/tests/quarkus/SampleCamelRoute.java
@@ -21,6 +21,26 @@ public class SampleCamelRoute extends EndpointRouteBuilder {
             .setBody().constant("Hello Camel! - simple")
             .to(stream("out"))
             .to(mock("result"));
+
+        from("timer:interval1")
+            .routeId("interval1Route")
+            .routeGroup("intervals")
+            .to("log:interval1");
+
+        from("timer:interval2")
+            .routeId("interval2Route")
+            .routeGroup("intervals")
+            .to("log:interval2");
+
+        from("timer:subject1")
+            .routeId("subject1Route")
+            .routeGroup("subjects")
+            .to("log:subject1");
+
+        from("timer:subject2")
+            .routeId("subject2Route")
+            .routeGroup("subjects")
+            .to("log:subject2");
     }
 
 }

--- a/tests/springboot/src/main/java/io/hawt/tests/spring/boot/SampleCamelRouter.java
+++ b/tests/springboot/src/main/java/io/hawt/tests/spring/boot/SampleCamelRouter.java
@@ -17,5 +17,25 @@ public class SampleCamelRouter extends RouteBuilder {
             .setBody().constant("Hello Camel! - simple")
             .to("stream:out")
             .to("mock:result");
+
+        from("timer:interval1")
+            .routeId("interval1Route")
+            .routeGroup("intervals")
+            .to("log:interval1");
+
+        from("timer:interval2")
+            .routeId("interval2Route")
+            .routeGroup("intervals")
+            .to("log:interval2");
+
+        from("timer:subject1")
+            .routeId("subject1Route")
+            .routeGroup("subjects")
+            .to("log:subject1");
+
+        from("timer:subject2")
+            .routeId("subject2Route")
+            .routeGroup("subjects")
+            .to("log:subject2");
     }
 }


### PR DESCRIPTION
In this PR:

- Added 4 grouped routes to the test apps, in total there are 6 routes now - 4 grouped explicitly, and 2 by default;
- Refactored and extended existing Camel Route tests to include grouped routes;
- Added new methods to navigate through groups in the Camel tree;

Now it should cover the issues fixed here - https://github.com/hawtio/hawtio-next/pull/1572