### PR TITLE
[E2E] Create auth enabled and disabled test app images and refactor t…

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -31,23 +31,39 @@ jobs:
       - name: Install
         run: |
           mvn ${MVN_ARGS} install
-      - name: Build images
+      - name: Build auth enabled images
         run: |
-          mvn ${MVN_ARGS} install -Dquarkus.container-image.build=true -pl examples/quarkus
-          mvn ${MVN_ARGS} install -DskipTests -Pe2e -Pdocker-testsuite -Ptests-docker -Dhawtio-container -pl :hawtio-test-suite,:hawtio-tests-quarkus,:hawtio-tests-springboot -am
-      - name: Display images
-        run: |
-          docker images
-      - name: Push image to Quay.io
+          mvn ${MVN_ARGS} install -DskipTests -Pe2e -Pdocker-testsuite -Ptests-docker -Dhawtio-container -pl :hawtio-test-suite,:hawtio-tests-quarkus,:hawtio-tests-springboot -am -Dhawtio.authenticationEnabled=true
+      - name: Push auth enabled images to Quay.io
         env:
           USERNAME: ${{ secrets.QUAY_USERNAME }}
           PASSWORD: ${{ secrets.QUAY_PASSWORD }}
         run: |
           docker login -u $USERNAME -p $PASSWORD quay.io
+
           docker tag hawtio-test-suite:${{ matrix.java }} quay.io/hawtio/hawtio-test-suite:${{ github.ref_name }}-${{ matrix.java }}
           docker tag hawtio-quarkus-app:${{ matrix.java }} quay.io/hawtio/hawtio-quarkus-test-app:${{ github.ref_name }}-${{ matrix.java }}
           docker tag hawtio-springboot-app:${{ matrix.java }} quay.io/hawtio/hawtio-springboot-test-app:${{ github.ref_name }}-${{ matrix.java }}
+
           for image in $(docker images --filter=reference='quay.io/hawtio/*' --format='{{.Repository}}:{{.Tag}}')
           do
             docker push $image
           done
+      - name: Build auth disabled images
+        run: |
+          mvn ${MVN_ARGS} install -DskipTests -Pe2e -Pdocker-testsuite -Ptests-docker -Dhawtio-container -pl :hawtio-test-suite,:hawtio-tests-quarkus,:hawtio-tests-springboot -am -Dhawtio.authenticationEnabled=false
+      - name: Push auth disabled images to Quay.io
+        env:
+          USERNAME: ${{ secrets.QUAY_USERNAME }}
+          PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+        run: |
+          docker login -u $USERNAME -p $PASSWORD quay.io
+
+          docker tag hawtio-quarkus-app:${{ matrix.java }} quay.io/hawtio/hawtio-quarkus-test-app:${{ github.ref_name }}-${{ matrix.java }}-noauth
+          docker tag hawtio-springboot-app:${{ matrix.java }} quay.io/hawtio/hawtio-springboot-test-app:${{ github.ref_name }}-${{ matrix.java }}-noauth
+          
+          docker push quay.io/hawtio/hawtio-quarkus-test-app:${{ github.ref_name }}-${{ matrix.java }}-noauth
+          docker push quay.io/hawtio/hawtio-springboot-test-app:${{ github.ref_name }}-${{ matrix.java }}-noauth
+      - name: Display images
+        run: |
+          docker images

--- a/tests/hawtio-test-suite/pom.xml
+++ b/tests/hawtio-test-suite/pom.xml
@@ -18,7 +18,7 @@
     <junit-platform-commons-version>1.13.4</junit-platform-commons-version>
     <egit-github-core-version>2.1.5</egit-github-core-version>
     <gson-version>2.13.1</gson-version>
-    <xtf.version>0.36</xtf.version>
+    <xtf.version>0.37</xtf.version>
   </properties>
 
   <dependencyManagement>

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/OpenshiftClient.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/OpenshiftClient.java
@@ -50,7 +50,7 @@ public class OpenshiftClient extends OpenShift {
         configBuilder
             .withNamespace(namespace)
 //            .withHttpsProxy(TestConfiguration.openshiftHttpsProxy())
-            .withBuildTimeout(60_000)
+            .withBuildTimeout(60_000L)
             .withRequestTimeout(120_000)
             .withConnectionTimeout(120_000)
             .withTrustCerts(true);

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/routes/CamelRouteDiagram.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/routes/CamelRouteDiagram.java
@@ -1,16 +1,20 @@
 package io.hawt.tests.features.pageobjects.fragments.camel.tabs.routes;
 
+import static com.codeborne.selenide.CollectionCondition.sizeGreaterThan;
 import static com.codeborne.selenide.Selenide.$$;
 
 import org.assertj.core.api.Assertions;
+import org.openqa.selenium.Rectangle;
 
-import com.codeborne.selenide.CollectionCondition;
 import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.SelenideElement;
 
-import java.awt.Rectangle;
+import java.awt.geom.Rectangle2D;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import io.hawt.tests.features.pageobjects.pages.camel.CamelPage;
 
@@ -19,31 +23,47 @@ import io.hawt.tests.features.pageobjects.pages.camel.CamelPage;
  */
 public class CamelRouteDiagram extends CamelPage {
     final private static ElementsCollection nodes = $$("[data-testid^='rf__node-']");
+    final private static ElementsCollection actualNodes = $$(".camel-node-content");
 
     /**
      * Check that routes diagram is present on this page.
      */
     public void diagramIsPresent() {
-        $$(".camel-node-content").shouldHave(CollectionCondition.sizeGreaterThan(1));
+        $$(".camel-node-content").shouldHave(sizeGreaterThan(1));
     }
 
     /**
      * Check that route nodes do not overlay/intersect.
      */
     public void nodesDoNotOverlay() {
-        for (int i = 0; i < nodes.size(); i++) {
-            Rectangle rect1 = toAwtRectangle(nodes.get(i).getRect());
-            String id1 = nodes.get(i).getAttribute("data-testid");
+        // Collect all node rectangles and IDs in one go (fewer WebDriver calls)
+        List<Rectangle2D> rects = actualNodes
+            .asFixedIterable()
+            .stream()
+            .map(el -> toAwtRectangle2D(el.getRect()))
+            .collect(Collectors.toList());
 
-            for (int j = i + 1; j < nodes.size(); j++) {
-                Rectangle rect2 = toAwtRectangle(nodes.get(j).getRect());
-                String id2 = nodes.get(j).getAttribute("data-testid");
+        List<String> ids = nodes
+            .asFixedIterable()
+            .stream()
+            .map(el -> el.getAttribute("data-testid"))
+            .toList();
 
-                Assertions.assertThat(rect1.intersects(rect2))
+        IntStream.range(0, rects.size()).forEach(i -> {
+            Rectangle2D rect1 = rects.get(i);
+            String id1 = ids.get(i);
+
+            IntStream.range(i + 1, rects.size()).forEach(j -> {
+                Rectangle2D rect2 = rects.get(j);
+                String id2 = ids.get(j);
+
+                boolean overlaps = rectanglesOverlap(rect1, rect2);
+
+                Assertions.assertThat(overlaps)
                     .as("Node %s at %s overlaps with node %s at %s", id1, rect1, id2, rect2)
                     .isFalse();
-            }
-        }
+            });
+        });
     }
 
     /**
@@ -52,10 +72,10 @@ public class CamelRouteDiagram extends CamelPage {
     public void noNodeDuplicationsExist() {
         Set<String> routeNodes = new HashSet<>();
         for (SelenideElement node : nodes) {
-            Rectangle rect = toAwtRectangle(node.getRect());
+            Rectangle2D rect = toAwtRectangle2D(node.getRect());
 
-            String routeNode = String.format("%s|%d,%d,%d,%d",
-                node.getAttribute("data-testid"), rect.x, rect.y, rect.width, rect.height);
+            String routeNode = String.format("%s|%f,%f,%f,%f",
+                node.getAttribute("data-testid"), rect.getX(), rect.getY(), rect.getWidth(), rect.getHeight());
 
             Assertions.assertThat(routeNodes.add(routeNode))
                 .as("Duplicate node found: %s", routeNode)
@@ -64,17 +84,31 @@ public class CamelRouteDiagram extends CamelPage {
     }
 
     /**
-     * Convert Selenium Rectangle to java awt Rectangle.
+     * Convert Selenium Rectangle to java.awt.geom.Rectangle2D.Double.
      *
      * @param seleniumRect Selenium Rectangle
      * @return java awt Rectangle
      */
-    private Rectangle toAwtRectangle(org.openqa.selenium.Rectangle seleniumRect) {
-        return new Rectangle(
+    private Rectangle2D.Double toAwtRectangle2D(Rectangle seleniumRect) {
+        return new Rectangle2D.Double(
             seleniumRect.getX(),
             seleniumRect.getY(),
             seleniumRect.getWidth(),
             seleniumRect.getHeight()
         );
+    }
+
+    /**
+     * Checks if two rectangles overlap or not.
+     *
+     * @param r1 first rectangle
+     * @param r2 second rectangle
+     * @return boolean if two rectangles overlap
+     */
+    private boolean rectanglesOverlap(Rectangle2D r1, Rectangle2D r2) {
+        return !(r1.getMaxX() < r2.getMinX() ||
+            r1.getMinX() > r2.getMaxX() ||
+            r1.getMaxY() < r2.getMinY() ||
+            r1.getMinY() > r2.getMaxY());
     }
 }

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/pages/HawtioPage.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/pages/HawtioPage.java
@@ -2,18 +2,12 @@ package io.hawt.tests.features.pageobjects.pages;
 
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.enabled;
-import static com.codeborne.selenide.Condition.exist;
-import static com.codeborne.selenide.Condition.hidden;
 import static com.codeborne.selenide.Condition.interactable;
-import static com.codeborne.selenide.Condition.visible;
-import static com.codeborne.selenide.Selectors.byAttribute;
-import static com.codeborne.selenide.Selectors.byTagAndText;
 import static com.codeborne.selenide.Selectors.byXpath;
 import static com.codeborne.selenide.Selenide.$;
 
 import org.openqa.selenium.By;
 
-import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.SelenideElement;
 
 import io.hawt.tests.features.pageobjects.fragments.Panel;
@@ -96,26 +90,10 @@ public class HawtioPage {
      */
     public void openTab(String tab) {
         final SelenideElement tabElement = $(byXpath("//a[text()='" + tab + "']"));
-        final SelenideElement scrollRightButton = $(byAttribute("aria-label", "Scroll right"));
-        final String currentCamelTreeNode = $(byXpath("//h1[contains(@class, 'title')]")).shouldBe(visible).getText();
-
-        // if the tab is not active, navigate to the tab
         if (!tabElement.has(cssClass("active"))) {
-
-            // if the tab is not displayed, refresh the page (workaround for a slow network connection)
-            // after the refresh, camel page is reset and camel tree is collapsed, so it is needed to get back
-            if (!tabElement.isDisplayed()) {
-                Selenide.refresh();
-                $(byAttribute("aria-label", "Expand Collapse")).shouldBe(enabled).click();
-                $(byTagAndText("button", currentCamelTreeNode)).shouldBe(visible).click();
-            }
-
-            // if the tab is hidden, scroll to the right
-            while (!tabElement.is(visible)) {
-                scrollRightButton.shouldBe(enabled).click();
-            }
-
-            tabElement.should(exist).shouldNotBe(hidden).click();
+            tabElement.scrollTo();
+            tabElement.shouldBe(enabled).click();
+            tabElement.shouldHave(cssClass("active"));
         }
     }
 

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/LoginLogout.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/LoginLogout.java
@@ -96,7 +96,7 @@ public class LoginLogout {
      * Check that Hawtio page is properly and fully loaded.
      */
     public static void hawtioIsLoaded() {
-        $("img.pf-v5-c-brand").should(exist, Duration.ofSeconds(20)).shouldBe(interactable);
+        $("img.pf-v5-c-brand").should(exist, Duration.ofSeconds(30)).shouldBe(interactable);
         $("#vertical-nav-toggle").should(exist).shouldBe(interactable);
     }
 }

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/deployment/OpenshiftDeployment.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/deployment/OpenshiftDeployment.java
@@ -23,7 +23,7 @@ public class OpenshiftDeployment implements AppDeployment {
     public void start() {
         HawtioOnlineUtils.deployOperator();
         host = HawtioOnlineUtils.deployNamespacedHawtio(DEFAULT_HAWTIO_NAME, TestConfiguration.getOpenshiftNamespace());
-        appDeployment = HawtioOnlineUtils.deployApplication(DEFAULT_APP_NAME, TestConfiguration.getRuntime(), TestConfiguration.getOpenshiftNamespace(), "latest");
+        appDeployment = HawtioOnlineUtils.deployApplication(DEFAULT_APP_NAME, TestConfiguration.getRuntime(), TestConfiguration.getOpenshiftNamespace(), "4.x-" + (System.getProperty("java.vm.specification.version", "17")));
     }
 
     @Override

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/camel/routes/CamelRoutesStepDefs.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/camel/routes/CamelRoutesStepDefs.java
@@ -2,14 +2,12 @@ package io.hawt.tests.features.stepdefinitions.camel.routes;
 
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import io.hawt.tests.features.config.TestConfiguration;
 import io.hawt.tests.features.pageobjects.fragments.camel.tabs.routes.CamelDebug;
 import io.hawt.tests.features.pageobjects.fragments.camel.tabs.routes.CamelProperties;
 import io.hawt.tests.features.pageobjects.fragments.camel.tabs.routes.CamelRouteDiagram;
 import io.hawt.tests.features.pageobjects.fragments.camel.tabs.routes.CamelRoutes;
 import io.hawt.tests.features.pageobjects.fragments.camel.tabs.routes.CamelSource;
 import io.hawt.tests.features.pageobjects.fragments.camel.tabs.routes.CamelTrace;
-import io.hawt.tests.features.setup.deployment.OpenshiftDeployment;
 
 public class CamelRoutesStepDefs {
     private final CamelDebug camelDebug = new CamelDebug();
@@ -78,9 +76,6 @@ public class CamelRoutesStepDefs {
 
     @Then("^Start debugging option is presented$")
     public void startDebuggingOptionIsPresented() {
-        if (TestConfiguration.getAppDeploymentMethod() instanceof OpenshiftDeployment && camelDebug.isDebuggingOn()) {
-            camelDebug.stopDebugging();
-        }
         camelDebug.startDebuggingOptionIsPresented();
     }
 

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/ClusterDiscoveryTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/ClusterDiscoveryTest.java
@@ -49,7 +49,7 @@ public class ClusterDiscoveryTest extends BaseHawtioOnlineTest {
         HawtioOnlineTestUtils.withCleanup(() -> {
             OpenshiftClient.get().createNamespace(namespace);
 
-            HawtioOnlineUtils.deployApplication("e2e-discover-app", "quarkus", namespace, "17");
+            HawtioOnlineUtils.deployApplication("e2e-discover-app", "springboot", namespace, "4.x-" + (System.getProperty("java.vm.specification.version", "17")));
 
             var discoverPage = new DiscoverTab();
             WaitUtils.untilAsserted(() -> {

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/HawtioOnlineShellTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/HawtioOnlineShellTest.java
@@ -2,13 +2,11 @@ package io.hawt.tests.openshift;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.awaitility.Awaitility;
 import org.openqa.selenium.NoSuchWindowException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -109,13 +107,13 @@ public class HawtioOnlineShellTest extends BaseHawtioOnlineTest {
 
             assertThat(p.stream().filter(pod -> pod.getStatus().equalsIgnoreCase("Running"))).hasSize(appDeployment.getStatus().getReplicas());
             return p;
-        }, 5, Duration.ofSeconds(5));
+        }, 5, Duration.ofSeconds(20));
 
         assertThat(pods.get(0)).satisfies(pod -> {
             final Pod podResource = OpenshiftClient.get().getPod(pod.getName());
 
             assertThat(pod.getContainerCount()).isEqualTo(pod.getContainerCount());
-            assertThat(pod.getRouteCount()).isEqualTo(2);
+            assertThat(pod.getRouteCount()).isEqualTo(6);
             assertThat(pod.getNamespace()).isEqualTo(podResource.getMetadata().getNamespace());
 
             assertThat(pod.getLabels()).containsAllEntriesOf(pod.getLabels());
@@ -137,12 +135,12 @@ public class HawtioOnlineShellTest extends BaseHawtioOnlineTest {
             WaitUtils.untilAsserted(() -> {
                 assertThat(deploymentEntry.getPods()).hasSize(3);
                 assertThat(deploymentEntry.getPods()).allMatch(pod -> pod.getStatus().toLowerCase().matches("running|containercreating"));
-            }, Duration.ofSeconds(10));
+            }, Duration.ofSeconds(20));
             //TODO: https://github.com/hawtio/hawtio-online/issues/290
 
         }, () -> {
             appDeployment.scale(1);
-            appDeployment.waitUntilReady(10, TimeUnit.SECONDS);
+            appDeployment.waitUntilReady(20, TimeUnit.SECONDS);
         });
     }
 
@@ -171,6 +169,6 @@ public class HawtioOnlineShellTest extends BaseHawtioOnlineTest {
             } else {
                 assertThat(parts[0]).isEqualToIgnoringCase(resourceType);
             }
-        }, Duration.ofSeconds(15));
+        }, Duration.ofSeconds(20));
     }
 }

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/HawtioOperatorTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/HawtioOperatorTest.java
@@ -78,7 +78,7 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
     @BeforeAll
     public static void setupApp() {
         String name = "camel-app-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
-        deployment = HawtioOnlineUtils.deployApplication(name, "springboot", TestConfiguration.getOpenshiftNamespace(), "21");
+        deployment = HawtioOnlineUtils.deployApplication(name, "springboot", TestConfiguration.getOpenshiftNamespace(), "4.x-" + (System.getProperty("java.vm.specification.version", "21")));
         podName = OpenshiftClient.get().pods().withLabel("app", name).list().getItems().get(0).getMetadata().getName();
     }
 
@@ -208,7 +208,8 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
             .resource(new NamespaceBuilder().withNewMetadata().withName(namespace).addToLabels("myLabel", namespace).endMetadata().build()).create();
 
         HawtioOnlineTestUtils.withCleanup(() -> {
-            HawtioOnlineUtils.deployApplication("selector-test-springboot", "quarkus", namespace, "21");
+            HawtioOnlineUtils.deployApplication("selector-test-springboot", "springboot", namespace, "4.x-" + (System.getProperty("java.vm.specification.version", "21")));
+
             runTest(spec -> {
 
                 Config config = new Config();

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/NamespacedDiscoveryTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/NamespacedDiscoveryTest.java
@@ -44,8 +44,8 @@ public class NamespacedDiscoveryTest extends BaseHawtioOnlineTest {
     public void testMultipleDeployments() {
         final String name = "e2e-hawtio-second-deployment";
         HawtioOnlineTestUtils.withCleanup(() -> {
-            final Deployment deployment = HawtioOnlineUtils.deployApplication(name, "quarkus",
-                TestConfiguration.getOpenshiftNamespace(), "17");
+            final Deployment deployment = HawtioOnlineUtils.deployApplication(name, "springboot",
+                TestConfiguration.getOpenshiftNamespace(), "4.x-" + (System.getProperty("java.vm.specification.version", "17")));
             OpenshiftClient.get().apps().deployments().resource(deployment).waitUntilReady(2, TimeUnit.MINUTES);
 
             WaitUtils.untilAsserted(() -> {
@@ -64,7 +64,7 @@ public class NamespacedDiscoveryTest extends BaseHawtioOnlineTest {
         final String deploymentName = "hawtio-discover-test";
         HawtioOnlineTestUtils.withCleanup(() -> {
             OpenshiftClient.get().createNamespace(namespace);
-            HawtioOnlineUtils.deployApplication(deploymentName, "quarkus", namespace, "17");
+            HawtioOnlineUtils.deployApplication(deploymentName, "springboot", namespace, "4.x-" + (System.getProperty("java.vm.specification.version", "17")));
 
             var discover = new DiscoverTab();
 

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/routes/camel_specific_route.feature
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/routes/camel_specific_route.feature
@@ -102,14 +102,6 @@ Feature: Checking the functionality of Camel Specific Route page.
     When User clicks on Camel "Properties" tab
     Then Default quartz properties of "simple" are Auto Startup: "true", Log Mask: "false", Delayer: "advanced"
 
-  Scenario: Check Camel Trace starts tracing
-    Given User is on "Camel" page
-    And User is on Camel "simple" item of "default" group of "routes" folder of "SampleCamel" context
-    And User clicks on Camel "Trace" tab
-    When User starts tracing
-    Then Tracing shows trace
-    And Tracing shows diagram
-
   Scenario: Check Camel Trace stops tracing
     Given User is on "Camel" page
     And User is on Camel "simple" item of "default" group of "routes" folder of "SampleCamel" context
@@ -117,3 +109,13 @@ Feature: Checking the functionality of Camel Specific Route page.
     When User stops tracing
     Then Tracing not shows trace
     And Tracing not shows diagram
+
+  Scenario: Check Camel Trace starts tracing
+    Given User is on "Camel" page
+    And User is on Camel "simple" item of "default" group of "routes" folder of "SampleCamel" context
+    And User clicks on Camel "Trace" tab
+    And User stops tracing
+    And Tracing not shows trace
+    When User starts tracing
+    Then Tracing shows trace
+    And Tracing shows diagram

--- a/tests/quarkus/pom.xml
+++ b/tests/quarkus/pom.xml
@@ -17,6 +17,7 @@
     <hawtio.managementPort>8080</hawtio.managementPort>
     <skipITs>true</skipITs>
     <image.name>hawtio-quarkus-app</image.name>
+    <hawtio.authenticationEnabled>true</hawtio.authenticationEnabled>
   </properties>
 
   <dependencyManagement>
@@ -77,6 +78,7 @@
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-quartz</artifactId>
     </dependency>
+
     <!--
       This dependency is mandatory for enabling Camel management
       via JMX / Hawtio.
@@ -172,6 +174,11 @@
         <groupId>io.quarkus.platform</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus-version}</version>
+        <configuration>
+          <systemProperties>
+            <quarkus.hawtio.authenticationEnabled>${hawtio.authenticationEnabled}</quarkus.hawtio.authenticationEnabled>
+          </systemProperties>
+        </configuration>
         <extensions>true</extensions>
         <executions>
           <execution>

--- a/tests/quarkus/src/main/resources/jolokia-access.xml
+++ b/tests/quarkus/src/main/resources/jolokia-access.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2009-2011 Roland Huss
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<restrict>
+
+  <!-- List of remote hosts which are allowed to access this agent. The name can be
+       given as IP or FQDN. If any of the given hosts matches, access will be allowed
+      (respecting further restrictions, though). If <remote> ... </remote> is given
+      without any host no access is allowed at all (probably not what you want).
+
+      You can also specify a subnetmask behind a numeric IP adress in which case any
+      host within the specified subnet is allowed to access the agent. The netmask can
+      be given either in CIDR format (e.g "/16") or as a full netmask (e.g. "/255.255.0.0")
+  -->
+  <!--
+  <remote>
+    <host>127.0.0.1</host>
+    <host>localhost</host>
+    <host>10.0.0.0/16</host>
+  </remote>
+  -->
+
+  <!--
+  Access restriction based on the HTTP method with which an Jolokia request was received.
+  The following example allows only HTTP POST requests. If the section is missing, all
+  HTTP requests methods are allowed.
+  -->
+  <!--
+  <http>
+    <method>post</method>
+  </http>
+  -->
+
+  <!--
+  List of allowed commands.
+
+  If this sections is present, it influence the following section.
+
+  For each command type present, the principle behaviour is allow this command for all
+  MBeans. To remove an MBean (attribute/operation), a <deny> section has to be added.
+
+  For each command type missing, the command is disabled by default. For certain MBeans
+  it can be selectively by enabled by using an <allow> section below
+
+  Known types are:
+
+  * read
+  * write
+  * exec
+  * list
+  * version
+  * search
+
+  A missing <commands> section implies that every operation type is allowed (and can
+  be selectively controlled by a <deny> section)
+  -->
+
+  <commands>
+    <command>read</command>
+    <command>write</command>
+    <command>exec</command>
+    <command>list</command>
+    <command>version</command>
+    <command>search</command>
+  </commands>
+
+  <!-- For each command type missing in a given <commands> section, for certain MBeans (which
+       be a pattern, too) an command be alloed. Note that an <allow> entry e.g. for reading
+       an attribute of an certain MBean has no influence if reading is enabled globally anyway -->
+  <!--
+    <allow>
+      <mbean>
+        <name>jolokia:type=Config</name>
+        <operation>*</operation>
+        <attribute>*</attribute>
+      </mbean>
+      <mbean>
+        <name>java.lang:type=Threading</name>
+        <operation>findDeadlockedThreads</operation>
+      </mbean>
+    </allow>
+  -->
+
+  <!-- MBean access can be restricted by a <deny> section for commands enabled in a <commands> section
+       (or when the <commands> section is missing completely in which case all commands are allowed)
+  -->
+  <deny>
+    <mbean>
+      <!-- Exposes user/password of data source, so we forbid this one -->
+      <name>com.mchange.v2.c3p0:type=PooledDataSource,*</name>
+      <attribute>properties</attribute>
+    </mbean>
+  </deny>
+
+
+  <cors>
+    <!-- Allow cross origin access -->
+    <allow-origin>*</allow-origin>
+    <!-- Use if Origin header can use https while the protocol is http (e.g., with TLS proxy) -->
+    <ignore-scheme/>
+  </cors>
+</restrict>

--- a/tests/springboot/pom.xml
+++ b/tests/springboot/pom.xml
@@ -18,6 +18,7 @@
     <hawtio.url>/actuator/hawtio</hawtio.url>
     <hawtio.managementPort>10001</hawtio.managementPort>
     <image.name>hawtio-springboot-app</image.name>
+    <hawtio.authenticationEnabled>true</hawtio.authenticationEnabled>
   </properties>
 
   <dependencyManagement>
@@ -185,6 +186,13 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+
     <plugins>
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/tests/springboot/src/main/java/io/hawt/tests/spring/boot/SpringBootService.java
+++ b/tests/springboot/src/main/java/io/hawt/tests/spring/boot/SpringBootService.java
@@ -5,14 +5,12 @@ import java.util.Optional;
 import jakarta.annotation.PostConstruct;
 
 import io.hawt.springboot.HawtioPlugin;
-import io.hawt.web.auth.AuthenticationConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
-import static io.hawt.web.auth.AuthenticationConfiguration.HAWTIO_AUTHENTICATION_ENABLED;
 import static io.hawt.web.auth.AuthenticationConfiguration.HAWTIO_REALM;
 import static io.hawt.web.auth.AuthenticationConfiguration.HAWTIO_ROLES;
 import static io.hawt.web.auth.AuthenticationConfiguration.HAWTIO_ROLE_PRINCIPAL_CLASSES;
@@ -24,7 +22,6 @@ public class SpringBootService {
 
     public static void main(String[] args) {
         System.setProperty("hawtio.proxyWhitelist", "localhost, 127.0.0.1");
-        System.setProperty(AuthenticationConfiguration.HAWTIO_AUTHENTICATION_ENABLED, "false");
         SpringApplication.run(SpringBootService.class, args);
     }
 
@@ -70,7 +67,12 @@ public class SpringBootService {
         setSystemPropertyIfNotSet(HAWTIO_REALM, "hawtio");
         setSystemPropertyIfNotSet(HAWTIO_ROLE_PRINCIPAL_CLASSES, "org.eclipse.jetty.security.jaas.JAASRole");
 
-        System.setProperty(HAWTIO_AUTHENTICATION_ENABLED, Boolean.getBoolean("debugMode") ? "false" : "true");
+        /*
+         * If enabled, this line dynamically controls Hawtio authentication based on the "debugMode" system property.
+         * NOTE: This overrides any build-time configuration (e.g., -Dhawtio.authenticationEnabled).
+         *
+         * System.setProperty(HAWTIO_AUTHENTICATION_ENABLED, Boolean.getBoolean("debugMode") ? "false" : "true");
+         */
     }
 
     private void setSystemPropertyIfNotSet(final String key, final String value) {

--- a/tests/springboot/src/main/resources/application.properties
+++ b/tests/springboot/src/main/resources/application.properties
@@ -27,7 +27,7 @@ camel.trace.enabled = true
 
 quartz.cron = 0/10 * * * * ?
 quartz.repeatInterval = 10000
-hawtio.authenticationEnabled=false
+hawtio.authenticationEnabled=${hawtio.authenticationEnabled}
 
 # Hawtio properties to change the behaviours for HTTP headers
 # (Hawtio version >2.15.1)


### PR DESCRIPTION
In this PR:

– Workflow file refactoring
– -The workflow image file now creates test application images with and without authorization (for online tests)
– Replace previously used test application images for online tests and configure them to be disabled for authorization and accessible via Hawtio Online
– Update the XTF library to avoid a fabric8/jakcson serialization error when patching/editing OpenShift resources
– Refactor tests to adapt to the updated test application to avoid flakiness and improve stability