### PR TITLE
[E2E] Sync test fix.

### DIFF
--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/online/DiscoverTab.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/online/DiscoverTab.java
@@ -85,8 +85,21 @@ public class DiscoverTab {
         final Map<String, DeploymentEntry> deployments = getDeployments();
         if (REPLICA_SET_WORKAROUND) {
             final List<DeploymentEntry> matchingEntries = deployments.entrySet().stream()
-                .filter(entry -> entry.getKey().startsWith(name) && entry.getValue().getPods().get(0).getNamespace().equals(namespace)).map(
-                    Map.Entry::getValue).collect(Collectors.toList());
+                .filter(entry -> {
+                    if (!entry.getKey().startsWith(name)) {
+                        return false;
+                    }
+
+                    List<PodEntry> pods = entry.getValue().getPods();
+                    if (pods == null || pods.isEmpty()) {
+                        return false;
+                    }
+
+                    return pods.get(0).getNamespace().equals(namespace);
+                })
+                .map(Map.Entry::getValue)
+                .collect(Collectors.toList());
+
             Assertions.assertThat(matchingEntries).hasSize(1);
             return matchingEntries.get(0);
         } else {

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/openshift/DeploymentEntry.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/openshift/DeploymentEntry.java
@@ -32,6 +32,6 @@ public class DeploymentEntry {
     }
 
     public List<PodEntry> getPods() {
-        return $(root).sibling(0).$(By.className("pf-v5-c-list")).$$(By.cssSelector("li.pf-v5-c-list__item")).asFixedIterable().stream().map(PodEntry::new).collect(Collectors.toList());
+        return $(root).sibling(0).$(By.className("pf-v5-c-list")).$$(By.cssSelector("li.pod-item-list-item")).asFixedIterable().stream().map(PodEntry::new).collect(Collectors.toList());
     }
 }

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/openshift/PodEntry.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/openshift/PodEntry.java
@@ -61,6 +61,18 @@ public class PodEntry {
         return Integer.parseInt($(root).$(By.className("pod-item-" + label)).innerText().split(" ")[0]);
     }
 
+    private String getContainerRatioText() {
+        return $(root).$(By.className("pod-item-containers")).innerText().split(" ")[0];
+    }
+
+    public int getReadyContainerCount() {
+        return Integer.parseInt(getContainerRatioText().split("/")[0].trim());
+    }
+
+    public int getTotalContainerCount() {
+        return Integer.parseInt(getContainerRatioText().split("/")[1].trim());
+    }
+
     public int getContainerCount() {
         return getNumFromLabel("containers");
     }
@@ -88,7 +100,7 @@ public class PodEntry {
     }
 
     public String getStatus() {
-        return $(root).$(By.cssSelector("svg.state-icon")).$(By.tagName("title")).innerText();
+        return $(root).$(By.cssSelector("span.state-text")).innerText();
     }
 
     public void connect() {

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/HawtioOnlineShellTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/HawtioOnlineShellTest.java
@@ -112,7 +112,8 @@ public class HawtioOnlineShellTest extends BaseHawtioOnlineTest {
         assertThat(pods.get(0)).satisfies(pod -> {
             final Pod podResource = OpenshiftClient.get().getPod(pod.getName());
 
-            assertThat(pod.getContainerCount()).isEqualTo(pod.getContainerCount());
+            assertThat(pod.getReadyContainerCount()).isEqualTo(pod.getTotalContainerCount());
+            assertThat(pod.getTotalContainerCount()).isEqualTo(podResource.getSpec().getContainers().size());
             assertThat(pod.getRouteCount()).isEqualTo(6);
             assertThat(pod.getNamespace()).isEqualTo(podResource.getMetadata().getNamespace());
 


### PR DESCRIPTION
In this PR I synced the test fixes from 4.x:
- Due to changes in UI, I had to adjust some test selectors;
- Fixed a logic of Pod Display test - now it compares total amount of pods with amount of pods which are ready displayed in UI;
-- Additionally, it checks and compares the Pods from UI and from the Resource obtained via OpenShift client call;
-- Added a few helper methods;

- Added a few extra checks for assertContainsDeployment method to get more clear info if something fails;