### PR TITLE
[E2E] Fix the image workflow and adjust Dockerfiles.

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -52,17 +52,11 @@ jobs:
           fi
           docker run --rm \
           -v /var/run/docker.sock:/var/run/docker.sock \
-          -v $PWD/$REPORT_DIR:/hawtio-test-suite/tests/hawtio-test-suite/target \
-          -v $PWD/$REPORT_DIR/build:/hawtio-test-suite/tests/hawtio-test-suite/build/ \
+          -v $PWD/$REPORT_DIR:/workspace/tests/hawtio-test-suite/target \
+          -v $PWD/$REPORT_DIR/build:/workspace/tests/hawtio-test-suite/build/ \
           --shm-size="2g" \
             hawtio-test-suite:${{ matrix.java }} -Pe2e-${runtime} -Dselenide.browser=${{ matrix.browser }} \
             -Dio.hawt.test.docker.image=hawtio-${runtime}-app:${{ matrix.java }} $extra_args
-      - name: Prepare report artifacts
-        if: always()
-        run: |
-          mkdir -p results/$REPORT_DIR/
-          cp $REPORT_DIR/cucumber-reports/* results/$REPORT_DIR/ 
-          ls $REPORT_DIR/cucumber-reports/
       - name: Archive test artifacts
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -56,9 +56,9 @@ jobs:
         run: |
           TAG_SUFFIX=${{ github.ref_name }}-${{ matrix.java }}
           JAVA_ARG="--build-arg JAVA_VERSION=${{ matrix.java }}"
-          docker buildx build --platform $PLATFORMS_TEST_SUITE $JAVA_ARG -t quay.io/hawtio/hawtio-test-suite:$TAG_SUFFIX --push ./tests/hawtio-test-suite/
-          docker buildx build --platform $PLATFORMS_TEST_APP $JAVA_ARG -t quay.io/hawtio/hawtio-quarkus-test-app:$TAG_SUFFIX --push ./tests/quarkus/
-          docker buildx build --platform $PLATFORMS_TEST_APP $JAVA_ARG -t quay.io/hawtio/hawtio-springboot-test-app:$TAG_SUFFIX --push ./tests/springboot/
+          docker buildx build --platform $PLATFORMS_TEST_SUITE $JAVA_ARG -f tests/hawtio-test-suite/Dockerfile -t quay.io/hawtio/hawtio-test-suite:$TAG_SUFFIX --push .
+          docker buildx build --platform $PLATFORMS_TEST_APP $JAVA_ARG -f tests/quarkus/Dockerfile -t quay.io/hawtio/hawtio-quarkus-test-app:$TAG_SUFFIX --push tests/quarkus
+          docker buildx build --platform $PLATFORMS_TEST_APP $JAVA_ARG -f tests/springboot/Dockerfile -t quay.io/hawtio/hawtio-springboot-test-app:$TAG_SUFFIX --push tests/springboot
       # --- Build and push auth-disabled images ---
       - name: Build auth-disabled JARs
         run: |
@@ -67,5 +67,5 @@ jobs:
         run: |
           TAG_SUFFIX=${{ github.ref_name }}-${{ matrix.java }}-noauth
           JAVA_ARG="--build-arg JAVA_VERSION=${{ matrix.java }}"
-          docker buildx build --platform $PLATFORMS_TEST_APP $JAVA_ARG -t quay.io/hawtio/hawtio-quarkus-test-app:$TAG_SUFFIX --push ./tests/quarkus/
-          docker buildx build --platform $PLATFORMS_TEST_APP $JAVA_ARG -t quay.io/hawtio/hawtio-springboot-test-app:$TAG_SUFFIX --push ./tests/springboot/
+          docker buildx build --platform $PLATFORMS_TEST_APP $JAVA_ARG -f tests/quarkus/Dockerfile -t quay.io/hawtio/hawtio-quarkus-test-app:$TAG_SUFFIX --push tests/quarkus
+          docker buildx build --platform $PLATFORMS_TEST_APP $JAVA_ARG -f tests/springboot/Dockerfile -t quay.io/hawtio/hawtio-springboot-test-app:$TAG_SUFFIX --push tests/springboot

--- a/tests/hawtio-test-suite/Dockerfile
+++ b/tests/hawtio-test-suite/Dockerfile
@@ -12,11 +12,13 @@ COPY --from=firefoxImage / /
 
 COPY --from=chromeImage / /
 
-WORKDIR hawtio-test-suite
+WORKDIR /workspace
 COPY ./ ./
 RUN mvn dependency:go-offline -Pe2e -pl :hawtio-test-suite -am -P!local-test-app-dependency
 RUN mvn clean install -Pe2e -DskipTests=true -pl :hawtio-test-suite -am -P!local-test-app-dependency
 
 RUN chown root /home/seluser/
 
-ENTRYPOINT ["bash" , "./tests/hawtio-test-suite/container_entrypoint.sh"]
+WORKDIR /workspace/tests/hawtio-test-suite
+
+ENTRYPOINT ["bash" , "./container_entrypoint.sh"]

--- a/tests/hawtio-test-suite/container_entrypoint.sh
+++ b/tests/hawtio-test-suite/container_entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # shellcheck disable=SC1091
-source env_init.sh
+source /hawtio-test-suite/env_init.sh
 export VNC_NO_PASSWORD=true
 Xvfb :99 -screen 0 1920x1080x24 &
 /opt/bin/start-vnc.sh &

--- a/tests/quarkus/src/main/docker/Dockerfile.jvm
+++ b/tests/quarkus/src/main/docker/Dockerfile.jvm
@@ -90,7 +90,7 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 COPY --chown=185 ./start-keycloak.sh /deployments/
 
 #Needed for quarkus rebuild inside container for some reason
-RUN ln -s /deployments/ /quarkus-app && chmod a+rw /quarkus-app
+RUN ln -s /deployments/ /quarkus-app && chmod -R a+rw /quarkus-app && chown -R 185:185 /deployments
 
 EXPOSE 8080
 USER 185
@@ -98,4 +98,4 @@ ENV AB_JOLOKIA_OFF=""
 ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
-CMD java -jar ${JAVA_OPTS} ${JAVA_APP_JAR}
+CMD java ${JAVA_OPTS} -jar ${JAVA_APP_JAR}

--- a/tests/springboot/Dockerfile
+++ b/tests/springboot/Dockerfile
@@ -11,4 +11,4 @@ USER 185
 ENV AB_JOLOKIA_OFF=""
 ENV JAVA_APP_JAR="/deployments/hawtio-springboot.jar"
 
-CMD java -jar ${JAVA_OPTS} ${JAVA_APP_JAR}
+CMD java ${JAVA_OPTS} -jar ${JAVA_APP_JAR}


### PR DESCRIPTION
This PR fixes the issue related to messed paths and POM files in the Build Image workflow.

I triggered the workflow manually, it produced and pushed the images - https://github.com/hawtio/hawtio/actions/runs/19263938890

Then I checked them by deploying test applications on OpenShift 4.21 running on s390x and on classic x86_64