### PR TITLE
[E2E] New tests checking IP masking feature.

### DIFF
--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/Tree.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/Tree.java
@@ -1,11 +1,13 @@
 package io.hawt.tests.features.pageobjects.fragments;
 
 import static com.codeborne.selenide.CollectionCondition.allMatch;
+import static com.codeborne.selenide.CollectionCondition.sizeGreaterThan;
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.hidden;
 import static com.codeborne.selenide.Condition.interactable;
+import static com.codeborne.selenide.Condition.matchText;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byAttribute;
 import static com.codeborne.selenide.Selectors.byClassName;
@@ -23,6 +25,7 @@ import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.SelenideElement;
 
 import java.time.Duration;
+import java.util.List;
 
 /**
  * Represents Tree menu in Hawtio (e.g. Camel, JMX).
@@ -139,5 +142,41 @@ public class Tree {
 
     private void assureLoaded() {
         $(By.className("pf-v5-c-tree-view__list")).should(exist, Duration.ofSeconds(10));
+    }
+
+    /**
+     * Verify if all IP addresses in the tree are currently masked with asterisks.
+     * Ensures all IPs are in a consistent state (all masked OR all unmasked).
+     *
+     * @return true if all IPs are masked (***.***.***.**), false if all IPs show actual numbers
+     * @throws AssertionError if IPs are in mixed state or not found
+     */
+    public boolean areAllIpAddressesMasked() {
+        final String anyIpPattern = "^(\\*{3}|\\d{1,3})\\.(\\*{3}|\\d{1,3})\\.(\\*{3}|\\d{1,3})\\.(\\*{3}|\\d{1,3})-.*$";
+        final String maskedIpPattern = "^\\*{3}\\.\\*{3}\\.\\*{3}\\.\\*{3}-.*$";
+        final String unmaskedIpPattern = "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}-.*$";
+
+        // Ensure tree and IP nodes exist
+        final ElementsCollection ipNodes = $$(".pf-v5-c-tree-view__node-text")
+            .as("Tree nodes")
+            .shouldHave(sizeGreaterThan(0))
+            .filter(matchText(anyIpPattern))
+            .as("IP connection nodes")
+            .shouldHave(sizeGreaterThan(0));
+
+        final List<String> ipTexts = ipNodes.texts();
+
+        // Check for consistent state
+        final boolean allMasked = ipTexts.stream().allMatch(text -> text.matches(maskedIpPattern));
+        final boolean allUnmasked = ipTexts.stream().allMatch(text -> text.matches(unmaskedIpPattern));
+
+        if (allMasked) return true;
+        if (allUnmasked) return false;
+
+        // Mixed state detected - fail with detailed error message
+        throw new AssertionError(
+            String.format("IP addresses are in inconsistent state. Expected all masked or all unmasked, but found mixed values: %s",
+                ipTexts)
+        );
     }
 }

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/endpoints/CamelBrowse.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/endpoints/CamelBrowse.java
@@ -35,7 +35,7 @@ public class CamelBrowse extends CamelPage {
     /**
      * Forward the selected message.
      *
-     * @param endpointURI where the message is forwared
+     * @param endpointURI where the message is forwarded
      */
     public void forwardSelectedMessage(String endpointURI) {
         clickButton("Forward");
@@ -62,5 +62,12 @@ public class CamelBrowse extends CamelPage {
      */
     public void detailsAreDisplayed(String message) {
         $(byTagName("pre")).shouldHave(exactText(message));
+    }
+
+    /**
+     * Close a message details window.
+     */
+    public void closeMessageDetailsWindow() {
+        clickButtonByAriaLabel("Close");
     }
 }

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/menu/Menu.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/menu/Menu.java
@@ -36,6 +36,8 @@ public class Menu {
         // Sometimes Selenide is faster than Hawtio and content is loaded properly
         emptyStateContent.shouldNot(exist, Duration.ofSeconds(10));
 
+        // Wait for the navigation item to be available before clicking
+        item.should(exist).shouldBe(interactable);
         item.click();
         toggleLeftSideBarIfOverlaysCamelTree();
     }

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/openshift/PodEntry.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/openshift/PodEntry.java
@@ -1,5 +1,6 @@
 package io.hawt.tests.features.pageobjects.fragments.openshift;
 
+import static com.codeborne.selenide.Condition.interactable;
 import static com.codeborne.selenide.Selenide.$;
 
 import org.apache.commons.lang3.NotImplementedException;
@@ -104,6 +105,6 @@ public class PodEntry {
     }
 
     public void connect() {
-        $(root).$(By.cssSelector(".pod-item-connect-button > button")).click();
+        $(root).$(By.cssSelector(".pod-item-connect-button > button")).shouldBe(interactable).click();
     }
 }

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/pages/HawtioPage.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/pages/HawtioPage.java
@@ -3,6 +3,7 @@ package io.hawt.tests.features.pageobjects.pages;
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.interactable;
+import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byXpath;
 import static com.codeborne.selenide.Selenide.$;
 
@@ -42,7 +43,7 @@ public class HawtioPage {
      * @param text on the given button
      */
     public HawtioPage clickButton(String text) {
-        $(byXpath("//button[text()[normalize-space() = '" + text + "']]")).shouldBe(enabled).click();
+        $(byXpath("//button[text()[normalize-space() = '" + text + "']]")).shouldBe(visible).shouldBe(enabled).click();
         return this;
     }
 
@@ -52,7 +53,7 @@ public class HawtioPage {
      * @param ariaLabel on the given button
      */
     public HawtioPage clickButtonByAriaLabel(String ariaLabel) {
-        $(byXpath("//button[@aria-label='" + ariaLabel + "']")).shouldBe(enabled).click();
+        $(byXpath("//button[@aria-label='" + ariaLabel + "']")).shouldBe(visible).shouldBe(enabled).click();
         return this;
     }
 

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/camel/endpoints/CamelEndpointsStepDefs.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/camel/endpoints/CamelEndpointsStepDefs.java
@@ -68,4 +68,9 @@ public class CamelEndpointsStepDefs {
     public void detailsOfTheMessageWithBodAreDisplayed(String message) {
         camelBrowse.detailsAreDisplayed(message);
     }
+
+    @And("^User closes a Message details window$")
+    public void userClosesMessageDetailsWindow() {
+        camelBrowse.closeMessageDetailsWindow();
+    }
 }

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/v1/hawtiospec/Resources.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/v1/hawtiospec/Resources.java
@@ -9,13 +9,13 @@ public class Resources implements io.fabric8.kubernetes.api.model.KubernetesReso
      * Claims lists the names of resources, defined in spec.resourceClaims,
      * that are used by this container.
      *
-     * This is an alpha field and requires enabling the
+     * This field depends on the
      * DynamicResourceAllocation feature gate.
      *
      * This field is immutable. It can only be set for containers.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("claims")
-    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private java.util.List<io.hawt.v1.hawtiospec.resources.Claims> claims;
 

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/v1alpha1/hawtiospec/Resources.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/v1alpha1/hawtiospec/Resources.java
@@ -9,13 +9,13 @@ public class Resources implements io.fabric8.kubernetes.api.model.KubernetesReso
      * Claims lists the names of resources, defined in spec.resourceClaims,
      * that are used by this container.
      *
-     * This is an alpha field and requires enabling the
+     * This field depends on the
      * DynamicResourceAllocation feature gate.
      *
      * This field is immutable. It can only be set for containers.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("claims")
-    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private java.util.List<io.hawt.v1alpha1.hawtiospec.resources.Claims> claims;
 

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/v2/HawtioSpec.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/v2/HawtioSpec.java
@@ -1,7 +1,7 @@
 package io.hawt.v2;
 
 @com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
-@com.fasterxml.jackson.annotation.JsonPropertyOrder({"auth","config","externalRoutes","metadataPropagation","nginx","rbac","replicas","resources","route","routeHostName","type","version"})
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"auth","config","externalRoutes","healthChecks","logging","metadataPropagation","nginx","rbac","replicas","resources","route","routeHostName","type","version"})
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 public class HawtioSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
 
@@ -51,6 +51,38 @@ public class HawtioSpec implements io.fabric8.kubernetes.api.model.KubernetesRes
 
     public void setExternalRoutes(java.util.List<String> externalRoutes) {
         this.externalRoutes = externalRoutes;
+    }
+
+    /**
+     * The Hawtio health checking configuration
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("healthChecks")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The Hawtio health checking configuration")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private io.hawt.v2.hawtiospec.HealthChecks healthChecks;
+
+    public io.hawt.v2.hawtiospec.HealthChecks getHealthChecks() {
+        return healthChecks;
+    }
+
+    public void setHealthChecks(io.hawt.v2.hawtiospec.HealthChecks healthChecks) {
+        this.healthChecks = healthChecks;
+    }
+
+    /**
+     * The Hawtio logging configuration
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("logging")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The Hawtio logging configuration")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private io.hawt.v2.hawtiospec.Logging logging;
+
+    public io.hawt.v2.hawtiospec.Logging getLogging() {
+        return logging;
+    }
+
+    public void setLogging(io.hawt.v2.hawtiospec.Logging logging) {
+        this.logging = logging;
     }
 
     /**

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/v2/hawtiospec/HealthChecks.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/v2/hawtiospec/HealthChecks.java
@@ -1,0 +1,72 @@
+package io.hawt.v2.hawtiospec;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"gatewayLivenessPeriod","gatewayReadinessPeriod","onlineLivenessPeriod","onlineReadinessPeriod"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+public class HealthChecks implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    /**
+     * Configure the period, in seconds, between gateway container liveness probe checks
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("gatewayLivenessPeriod")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Configure the period, in seconds, between gateway container liveness probe checks")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private Integer gatewayLivenessPeriod;
+
+    public Integer getGatewayLivenessPeriod() {
+        return gatewayLivenessPeriod;
+    }
+
+    public void setGatewayLivenessPeriod(Integer gatewayLivenessPeriod) {
+        this.gatewayLivenessPeriod = gatewayLivenessPeriod;
+    }
+
+    /**
+     * Configure the period, in seconds, between gateway container readiness probe checks
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("gatewayReadinessPeriod")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Configure the period, in seconds, between gateway container readiness probe checks")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private Integer gatewayReadinessPeriod;
+
+    public Integer getGatewayReadinessPeriod() {
+        return gatewayReadinessPeriod;
+    }
+
+    public void setGatewayReadinessPeriod(Integer gatewayReadinessPeriod) {
+        this.gatewayReadinessPeriod = gatewayReadinessPeriod;
+    }
+
+    /**
+     * Configure the period, in seconds, between online container liveness probe checks
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("onlineLivenessPeriod")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Configure the period, in seconds, between online container liveness probe checks")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private Integer onlineLivenessPeriod;
+
+    public Integer getOnlineLivenessPeriod() {
+        return onlineLivenessPeriod;
+    }
+
+    public void setOnlineLivenessPeriod(Integer onlineLivenessPeriod) {
+        this.onlineLivenessPeriod = onlineLivenessPeriod;
+    }
+
+    /**
+     * Configure the period, in seconds, between online container readiness probe checks
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("onlineReadinessPeriod")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Configure the period, in seconds, between online container readiness probe checks")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private Integer onlineReadinessPeriod;
+
+    public Integer getOnlineReadinessPeriod() {
+        return onlineReadinessPeriod;
+    }
+
+    public void setOnlineReadinessPeriod(Integer onlineReadinessPeriod) {
+        this.onlineReadinessPeriod = onlineReadinessPeriod;
+    }
+}
+

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/v2/hawtiospec/Logging.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/v2/hawtiospec/Logging.java
@@ -1,0 +1,58 @@
+package io.hawt.v2.hawtiospec;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"gatewayLogLevel","maskIPAddresses","onlineLogLevel"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+public class Logging implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    /**
+     * Configure gateway log level {info|debug}
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("gatewayLogLevel")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Configure gateway log level {info|debug}")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String gatewayLogLevel;
+
+    public String getGatewayLogLevel() {
+        return gatewayLogLevel;
+    }
+
+    public void setGatewayLogLevel(String gatewayLogLevel) {
+        this.gatewayLogLevel = gatewayLogLevel;
+    }
+
+    /**
+     * Turn on/off the masking of IP addresses in logging {true|false} (off by default)
+     * Warning: this can cause issues if ip address are part of MBean Idenfifiers so
+     * use with caution.
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("maskIPAddresses")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Turn on/off the masking of IP addresses in logging {true|false} (off by default)\nWarning: this can cause issues if ip address are part of MBean Idenfifiers so\nuse with caution.")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String maskIPAddresses;
+
+    public String getMaskIPAddresses() {
+        return maskIPAddresses;
+    }
+
+    public void setMaskIPAddresses(String maskIPAddresses) {
+        this.maskIPAddresses = maskIPAddresses;
+    }
+
+    /**
+     * Configure online log level {emerg|alert|crit|error|warn|notice|info}
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("onlineLogLevel")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Configure online log level {emerg|alert|crit|error|warn|notice|info}")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String onlineLogLevel;
+
+    public String getOnlineLogLevel() {
+        return onlineLogLevel;
+    }
+
+    public void setOnlineLogLevel(String onlineLogLevel) {
+        this.onlineLogLevel = onlineLogLevel;
+    }
+}
+

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/v2/hawtiospec/Resources.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/v2/hawtiospec/Resources.java
@@ -9,13 +9,13 @@ public class Resources implements io.fabric8.kubernetes.api.model.KubernetesReso
      * Claims lists the names of resources, defined in spec.resourceClaims,
      * that are used by this container.
      *
-     * This is an alpha field and requires enabling the
+     * This field depends on the
      * DynamicResourceAllocation feature gate.
      *
      * This field is immutable. It can only be set for containers.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("claims")
-    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private java.util.List<io.hawt.v2.hawtiospec.resources.Claims> claims;
 

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/endpoints/camel_specific_endpoint.feature
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/endpoints/camel_specific_endpoint.feature
@@ -66,3 +66,4 @@ Feature: Checking the functionality of a Camel Specific Endpoint page.
     And User clicks on Camel "Browse" tab
     When User clicks on the message with "Hello Test" body
     Then Details of the message with "Hello Test" body are displayed
+    And User closes a Message details window

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/panel/preferences/preferences.feature
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/panel/preferences/preferences.feature
@@ -22,15 +22,6 @@ Feature: Checking the functionality of a Preferences tab
     Examples:
       |Connect      |
 
-  Scenario: Check that Home tab works
-    Given User clicks on "Preferences" option in hawtio drop-down menu
-    And User is on "Home" tab of Preferences page
-    When User toggles the show vertical navigation field
-    When User clicks on Reset button
-    And User confirms modal "reset-settings-modal" resetting with confirmation "You are about to reset all the Hawtio settings." and clicks reset button "[data-testid='reset-btn']"
-
-    Then User is presented with a successful alert message
-
   Scenario: Check that Console Logs tab works
     Given User clicks on "Preferences" option in hawtio drop-down menu
     And User is on "Console Logs" tab of Preferences page
@@ -38,6 +29,15 @@ Feature: Checking the functionality of a Preferences tab
     Then User adds child logger
     And User sees added child logger
     And User is able to delete child logger
+
+  @notOnline
+  Scenario: Check that Home tab works
+    Given User clicks on "Preferences" option in hawtio drop-down menu
+    And User is on "Home" tab of Preferences page
+    When User toggles the show vertical navigation field
+    When User clicks on Reset button
+    And User confirms modal "reset-settings-modal" resetting with confirmation "You are about to reset all the Hawtio settings." and clicks reset button "[data-testid='reset-btn']"
+    Then User is presented with a successful alert message
 
   @notOnline
   Scenario: Check that Connect tab works
@@ -50,15 +50,9 @@ Feature: Checking the functionality of a Preferences tab
     Then User confirms modal "clear-connections-modal" resetting with confirmation "You are about to clear all saved connection settings." and clicks reset button "[data-testid='clear-btn']"
     And User is presented with a successful alert message
 
-  @notHawtioNext @notJBang
+  @notOnline @notHawtioNext @notJBang
   Scenario: Check that Sample Plugin tab works 
     Given User clicks on "Preferences" option in hawtio drop-down menu
     And User is on "Sample Plugin" tab of Preferences page
     Then Content section has h2 title "Sample Plugin"
     And Content section has paragraph "Preferences view for the custom plugin."
-    
-
-
-
-
-


### PR DESCRIPTION
In this PR:

- New tests to check IP masking feature (Hawtio Online) when enabled and disabled;
- Updated CRD-s which are used by e2e online tests;
- Stabilized flaky tests related to operator testing;
- Disabled Plugin tests and Reset settings scenarios in Hawtio Online tests (they were causing issues);
- Improved some other test behaviours;

I will do similar things for 5.x branch as well, but it will require extra refactoring to satisfy PFv6 changes.