### PR TITLE
Return escaped json in UserServlet to fix #4240

### DIFF
--- a/hawtio-system/src/main/java/io/hawt/web/auth/UserServlet.java
+++ b/hawtio-system/src/main/java/io/hawt/web/auth/UserServlet.java
@@ -1,14 +1,15 @@
 package io.hawt.web.auth;
 
-import java.io.IOException;
-
+import io.hawt.web.ServletHelpers;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import org.jolokia.json.JSONWriter;
 
-import io.hawt.web.ServletHelpers;
+import java.io.IOException;
+import java.io.StringWriter;
 
 /**
  * Returns the username associated with the current session, if any
@@ -28,20 +29,23 @@ public class UserServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         if (!authConfiguration.isEnabled()) {
-            ServletHelpers.sendJSONResponse(response, wrapQuote(DEFAULT_USER));
+            ServletHelpers.sendJSONResponse(response, toJsonString(DEFAULT_USER));
             return;
         }
 
         String username = getUsername(request, response);
+
         if (username == null) {
             ServletHelpers.doForbidden(response);
             return;
         }
-        ServletHelpers.sendJSONResponse(response, wrapQuote(username));
+        ServletHelpers.sendJSONResponse(response, toJsonString(username));
     }
 
-    private String wrapQuote(String str) {
-        return "\"" + str + "\"";
+    private String toJsonString(String str) throws IOException {
+        var json = new StringWriter();
+        JSONWriter.serialize(str, json);
+        return json.toString();
     }
 
     protected String getUsername(HttpServletRequest request, HttpServletResponse response) {

--- a/hawtio-system/src/test/java/io/hawt/web/auth/UserServletTest.java
+++ b/hawtio-system/src/test/java/io/hawt/web/auth/UserServletTest.java
@@ -1,0 +1,131 @@
+package io.hawt.web.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+class UserServletTest {
+
+    private UserServlet userServlet;
+    private AuthenticationConfiguration authConfiguration;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private ByteArrayOutputStream outputStream;
+    private PrintWriter writer;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        userServlet = new UserServlet();
+        authConfiguration = mock(AuthenticationConfiguration.class);
+        userServlet.authConfiguration = authConfiguration;
+
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+
+        outputStream = new ByteArrayOutputStream();
+        writer = new PrintWriter(outputStream);
+        when(response.getWriter()).thenReturn(writer);
+    }
+
+    private void doGet() throws IOException {
+        userServlet.doGet(request, response);
+        writer.flush();
+    }
+
+    @Test
+    void testDoGetWhenAuthenticationDisabled() throws Exception {
+        when(authConfiguration.isEnabled()).thenReturn(false);
+
+        doGet();
+
+        assertThat(outputStream.toString(), equalTo("\"public\"\n"));
+    }
+
+    @Test
+    void testDoGetWithSpringSecurityWhenUserExists() throws Exception {
+        when(authConfiguration.isEnabled()).thenReturn(true);
+        when(authConfiguration.isSpringSecurityEnabled()).thenReturn(true);
+        when(request.getRemoteUser()).thenReturn("testuser");
+
+        doGet();
+
+        assertThat(outputStream.toString(), equalTo("\"testuser\"\n"));
+    }
+
+    @Test
+    void testDoGetWithSpringSecurityWhenUserDoesNotExist() throws Exception {
+        when(authConfiguration.isEnabled()).thenReturn(true);
+        when(authConfiguration.isSpringSecurityEnabled()).thenReturn(true);
+        when(request.getRemoteUser()).thenReturn(null);
+
+        userServlet.doGet(request, response);
+
+        verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN);
+        verify(response).setContentLength(0);
+        verify(response).flushBuffer();
+    }
+
+    @Test
+    void testDoGetWhenUserHasDomainPrefix() throws Exception {
+        when(authConfiguration.isEnabled()).thenReturn(true);
+        when(authConfiguration.isSpringSecurityEnabled()).thenReturn(true);
+        when(request.getRemoteUser()).thenReturn("domain\\testuser");
+
+        doGet();
+
+        assertThat(outputStream.toString(), equalTo("\"domain\\\\testuser\"\n"));
+    }
+
+    @Test
+    void testDoGetWithSessionWhenUserExists() throws Exception {
+        HttpSession session = mock(HttpSession.class);
+        when(authConfiguration.isEnabled()).thenReturn(true);
+        when(authConfiguration.isSpringSecurityEnabled()).thenReturn(false);
+        when(request.getSession(false)).thenReturn(session);
+        when(session.getAttribute("user")).thenReturn("sessionuser");
+
+        doGet();
+
+        assertThat(outputStream.toString(), equalTo("\"sessionuser\"\n"));
+    }
+
+    @Test
+    void testDoGetWhenNoSession() throws Exception {
+        when(authConfiguration.isEnabled()).thenReturn(true);
+        when(authConfiguration.isSpringSecurityEnabled()).thenReturn(false);
+        when(request.getSession(false)).thenReturn(null);
+
+        doGet();
+
+        verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN);
+        verify(response).setContentLength(0);
+        verify(response).flushBuffer();
+    }
+
+    @Test
+    void testDoGetWhenSessionExistsButNoUserAttribute() throws Exception {
+        HttpSession session = mock(HttpSession.class);
+        when(authConfiguration.isEnabled()).thenReturn(true);
+        when(authConfiguration.isSpringSecurityEnabled()).thenReturn(false);
+        when(request.getSession(false)).thenReturn(session);
+        when(session.getAttribute("user")).thenReturn(null);
+
+        doGet();
+
+        verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN);
+        verify(response).setContentLength(0);
+        verify(response).flushBuffer();
+    }
+
+
+}


### PR DESCRIPTION
I replaced the `wrapQuote` method with json serialization to ensure that we always return a proper json string.