### PR TITLE
[E2E] Align versions and refactor the test automations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <httpcore-version>4.4.16</httpcore-version>
     <httpclient-version>4.5.14</httpclient-version>
     <jackson-version>2.19.2</jackson-version>
-    <junit5-version>6.0.0</junit5-version>
+    <junit5-version>5.14.0</junit5-version>
     <log4j2-version>2.25.3</log4j2-version>
     <mockito-core-version>5.20.0</mockito-core-version>
     <nimbusds-jose-version>10.6</nimbusds-jose-version>

--- a/tests/hawtio-test-suite/pom.xml
+++ b/tests/hawtio-test-suite/pom.xml
@@ -14,8 +14,6 @@
   <properties>
     <image.name>hawtio-test-suite</image.name>
     <local-app>true</local-app>
-    <logback-classic-version>1.5.21</logback-classic-version>
-    <junit-platform-commons-version>1.13.4</junit-platform-commons-version>
     <egit-github-core-version>2.1.5</egit-github-core-version>
     <gson-version>2.13.2</gson-version>
     <xtf.version>0.37</xtf.version>
@@ -55,12 +53,10 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>${logback-classic-version}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-commons</artifactId>
-      <version>${junit-platform-commons-version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.mylyn.github</groupId>
@@ -215,7 +211,7 @@
     <dependency>
       <groupId>com.github.dasniko</groupId>
       <artifactId>testcontainers-keycloak</artifactId>
-      <version>4.0.1</version>
+      <version>4.1.0</version>
     </dependency>
 
   </dependencies>

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/config/TestConfiguration.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/config/TestConfiguration.java
@@ -4,7 +4,7 @@ import org.junit.Assume;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/hooks/LoginLogoutHooks.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/hooks/LoginLogoutHooks.java
@@ -1,7 +1,9 @@
 package io.hawt.tests.features.hooks;
 
 import com.codeborne.selenide.Selenide;
+import com.codeborne.selenide.WebDriverRunner;
 
+import io.cucumber.java.AfterAll;
 import io.cucumber.java.Before;
 import io.hawt.tests.features.config.TestConfiguration;
 import io.hawt.tests.features.setup.LoginLogout;
@@ -13,7 +15,7 @@ public class LoginLogoutHooks {
 
     @Before
     public static void before() {
-        if (!init) {
+        if (!init || !WebDriverRunner.hasWebDriverStarted()) {
             WebDriver.setup();
             LoginLogout.login(TestConfiguration.getAppUsername(), TestConfiguration.getAppPassword());
             init = true;
@@ -25,5 +27,17 @@ public class LoginLogoutHooks {
             }
         }
         LoginLogout.hawtioIsLoaded();
+    }
+
+    /**
+     * Closes the browser on the MAIN THREAD after ALL tests complete.
+     */
+    @AfterAll
+    public static void tearDownAll() {
+        if (WebDriverRunner.hasWebDriverStarted()) {
+            System.out.println("Tearing down WebDriver on main thread after all tests...");
+            Selenide.closeWebDriver();
+            System.out.println("WebDriver closed successfully");
+        }
     }
 }

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/OpenshiftClient.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/OpenshiftClient.java
@@ -74,6 +74,23 @@ public class OpenshiftClient extends OpenShift {
     }
 
     /**
+     * Close the OpenShift client and release resources.
+     */
+    public static void closeClient() {
+        if (client != null) {
+            LOG.info("Closing OpenShift client");
+            try {
+                client.close();
+                LOG.info("OpenShift client closed successfully");
+            } catch (Exception e) {
+                LOG.warn("Error closing OpenShift client", e);
+            } finally {
+                client = null;
+            }
+        }
+    }
+
+    /**
      * Create namespace with given name.
      *
      * @param name of namespace to be created

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/deployment/KeycloakDeployment.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/deployment/KeycloakDeployment.java
@@ -7,28 +7,34 @@ import io.hawt.tests.features.config.TestConfiguration;
 
 public class KeycloakDeployment {
 
-    private static KeycloakContainer container = new KeycloakContainer(TestConfiguration.getKeycloakImage())
-        .withRealmImportFile("hawtio-demo-realm.json");
+    private static KeycloakContainer container;
+
+    private static KeycloakContainer getContainer() {
+        if (container == null) {
+            container = new KeycloakContainer(TestConfiguration.getKeycloakImage()).withRealmImportFile("hawtio-demo-realm.json");
+        }
+        return container;
+    }
 
     public static void start() {
-        container.start();
+        getContainer().start();
     }
 
     public static void stop() {
-        if (container.isRunning()) {
+        if (container != null && container.isRunning()) {
             container.stop();
         }
     }
 
     public static String getIssuerURL() {
-        return container.getAuthServerUrl() + "/realms/hawtio-demo";
+        return getContainer().getAuthServerUrl() + "/realms/hawtio-demo";
     }
 
     public static Keycloak adminClient() {
-        return container.getKeycloakAdminClient();
+        return getContainer().getKeycloakAdminClient();
     }
 
     public static String getURL() {
-        return container.getAuthServerUrl();
+        return getContainer().getAuthServerUrl();
     }
 }

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/deployment/OpenshiftDeployment.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/deployment/OpenshiftDeployment.java
@@ -30,7 +30,12 @@ public class OpenshiftDeployment implements AppDeployment {
     public void stop() {
         if (TestConfiguration.openshiftNamespaceDelete()) {
             LOG.info("Undeploying Hawtio project {}", TestConfiguration.getOpenshiftNamespace());
-            OpenshiftClient.get().namespaces().withName(TestConfiguration.getOpenshiftNamespace()).delete();
+            LOG.info("Calling namespace delete...");
+            OpenshiftClient.get().namespaces()
+                .withName(TestConfiguration.getOpenshiftNamespace())
+                .withGracePeriod(0L)
+                .delete();
+            LOG.info("Namespace delete call returned");
         }
     }
 

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/utils/BaseHawtioOnlineTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/utils/BaseHawtioOnlineTest.java
@@ -14,6 +14,7 @@ import com.codeborne.selenide.WebDriverRunner;
 import io.hawt.tests.features.config.TestConfiguration;
 import io.hawt.tests.features.hooks.DeployAppHook;
 import io.hawt.tests.features.pageobjects.pages.openshift.HawtioOnlineLoginPage;
+import io.hawt.tests.features.setup.WebDriver;
 import io.hawt.tests.features.setup.deployment.OpenshiftDeployment;
 
 @OpenshiftTest
@@ -28,6 +29,7 @@ public class BaseHawtioOnlineTest {
         openshiftDeployment = (OpenshiftDeployment) TestConfiguration.getAppDeploymentMethod();
         DeployAppHook.appSetup();
         openshiftDeployment.restartApp();
+        WebDriver.setup();
         Selenide.open(DeployAppHook.getBaseURL(), HawtioOnlineLoginPage.class)
             .login(TestConfiguration.getOpenshiftUsername(), TestConfiguration.getOpenshiftPassword());
     }

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/setup/suites/CucumberTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/setup/suites/CucumberTest.java
@@ -1,12 +1,12 @@
 package io.hawt.tests.setup.suites;
 
 import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("io/hawt/tests/features/")
+@SelectPackages("io.hawt.tests.features")
 public class CucumberTest {
 
 }

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -16,12 +16,14 @@
 
   <properties>
     <http5-version>5.3.1</http5-version>
-    <slf4j-version>2.0.9</slf4j-version>
-    <selenium-version>4.31.0</selenium-version>
-    <selenide-version>7.2.0</selenide-version>
-    <cucumber-version>7.22.1</cucumber-version>
-    <testcontainers-version>1.21.3</testcontainers-version>
+    <slf4j-version>2.0.17</slf4j-version>
+    <selenium-version>4.40.0</selenium-version>
+    <selenide-version>7.13.0</selenide-version>
+    <cucumber-version>7.33.0</cucumber-version>
+    <testcontainers-version>2.0.3</testcontainers-version>
     <awaitility-version>4.3.0</awaitility-version>
+    <logback-classic-version>1.5.25</logback-classic-version>
+    <junit-platform-commons-version>1.14.2</junit-platform-commons-version>
     <!-- Used for testing different versions of the Hawtio project then the current one - i.e. testing 4.0.0 with a SNAPSHOT version -->
     <hawtio.bom.version>${project.version}</hawtio.bom.version>
   </properties>
@@ -48,6 +50,67 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <!-- Explicit JUnit Jupiter version management to override Spring Boot BOM in child modules -->
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>${junit5-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>${junit5-version}</version>
+      </dependency>
+
+      <!-- Explicit Platform version management to override Spring Boot BOM in child modules -->
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-commons</artifactId>
+        <version>${junit-platform-commons-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-engine</artifactId>
+        <version>${junit-platform-commons-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-launcher</artifactId>
+        <version>${junit-platform-commons-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-suite-api</artifactId>
+        <version>${junit-platform-commons-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-suite-engine</artifactId>
+        <version>${junit-platform-commons-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-suite-commons</artifactId>
+        <version>${junit-platform-commons-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-suite</artifactId>
+        <version>${junit-platform-commons-version}</version>
+      </dependency>
+
+      <!-- Explicit logback version management to override Spring Boot BOM in child modules -->
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback-classic-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${logback-classic-version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -59,6 +122,7 @@
         <configuration>
           <redirectTestOutputToFile>false</redirectTestOutputToFile>
           <forkedProcessTimeoutInSeconds>0</forkedProcessTimeoutInSeconds>
+          <forkedProcessExitTimeoutInSeconds>10</forkedProcessExitTimeoutInSeconds>
         </configuration>
       </plugin>
     </plugins>

--- a/tests/quarkus/pom.xml
+++ b/tests/quarkus/pom.xml
@@ -30,13 +30,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>${junit5-version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>io.quarkus.platform</groupId>
         <artifactId>quarkus-bom</artifactId>
         <version>${quarkus-version}</version>


### PR DESCRIPTION
The reason of this PR is the dependabot's attempt to update the Cucumber and Testcontainers which caused test failures.
Deeper investigation discovered several issues related to various framework versions mismatch, code logic changes, some deprecations and flakiness of the tests.

As an example, JVM shutdown was hanging due to (a new issue after the version upgrades):
1. ThreadLocal Trap - WebDriver in shutdown hook couldn't access main thread's WebDriver
2. Testcontainers Ryuk starting even when not needed
3. Lingering HTTP threads from Kubernetes client
4. Login attempts during shutdown for skipped scenarios

**The changes made in this specific PR:**

**Dependency Updates**

  - Cucumber: 7.22.1 → 7.33.0
  - JUnit Platform: 6.0.0 → 5.14.0 (this is the correct version supported by Cucumber, before it worked because of the left legacy code)
  - Testcontainers: 1.21.3 → 2.0.3

 **Changes Required After Dependency Updates**

***tests/pom.xml - Version Management***
- Added explicit logback-classic and logback-core version management to override Spring Boot BOM (fixes version mismatch causing NoSuchMethodError)
  - For some reason the Spring Boot BOM was bringing older versions of JUnit causing versions mismatch and other related issues, so the solution was to explicitly define versions until the update of SB BOM
- Added explicit JUnit Jupiter and JUnit Platform version management (7 artifacts total) to ensure consistent versions across child modules
- Added forkedProcessExitTimeoutInSeconds=10 to prevent infinite waits during JVM shutdown

***CucumberTest.java - Fix Deprecation Warning***
- Changed from @SelectClasspathResource to @SelectPackages (Cucumber 7.33.0 deprecation fix)

***SkipTestsHook.java - Prevent Shutdown Hangs***
- Added scenario status check to prevent login attempts for skipped scenarios during shutdown

***KeycloakDeployment.java - Lazy Initialization***
- Changed from eager static initialization to lazy initialization to prevent Testcontainers/Ryuk from starting when Keycloak is not used

***LoginLogoutHooks.java - Fix ThreadLocal Trap***
- Changed from After to AfterAll for WebDriver cleanup
- WebDriver now closes on the main thread (not shutdown hook) to fix ThreadLocal access issue
- Matches browser lifecycle: opened once, closed once

***DeployAppHook.java - Simplified Cleanup***
- Removed WebDriver cleanup from shutdown hook (now in LoginLogoutHooks)
- Added OpenshiftClient.closeClient() call to properly shut down Kubernetes client

***OpenshiftClient.java - Resource Cleanup***
- Added closeClient() method to properly shut down Kubernetes client and release HTTP connection pool threads

***OpenshiftDeployment.java - Non-blocking Namespace Deletion***
- Added .withGracePeriod(0L) to namespace deletion to prevent hanging when finalizers keep namespace in Terminating state

***BaseHawtioOnlineTest.java - WebDriver Configuration***
- Added WebDriver.setup() call in BeforeAll to apply configuration (headless mode, browser options) before opening browser

