### PR TITLE
Work around missing Quarkus ResourceNotFoundData bean in dev mode when camel-quarkus-core is added to project dependencies

### DIFF
--- a/platforms/quarkus/runtime/pom.xml
+++ b/platforms/quarkus/runtime/pom.xml
@@ -102,6 +102,9 @@
             </goals>
             <configuration>
               <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+              <conditionalDevDependencies>
+                <artifact>io.quarkus:quarkus-devui-deployment:${quarkus-version}</artifact>
+              </conditionalDevDependencies>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Relates to #4203.