### PR TITLE
[E2E] New tests checking IP masking feature for 5.x branch.

### DIFF
--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/endpoints/CamelBrowse.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/endpoints/CamelBrowse.java
@@ -40,7 +40,7 @@ public class CamelBrowse extends CamelPage {
     /**
      * Forward the selected message.
      *
-     * @param endpointURI where the message is forwared
+     * @param endpointURI where the message is forwarded
      */
     public void forwardSelectedMessage(String endpointURI) {
         clickButton("Forward");
@@ -67,5 +67,12 @@ public class CamelBrowse extends CamelPage {
      */
     public void detailsAreDisplayed(String message) {
         $(byTagName("pre")).shouldHave(exactText(message));
+    }
+
+    /**
+     * Close a message details window.
+     */
+    public void closeMessageDetailsWindow() {
+        clickButtonByAriaLabel("Close");
     }
 }

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/menu/Menu.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/menu/Menu.java
@@ -36,7 +36,8 @@ public class Menu {
         // Sometimes Selenide is faster than Hawtio and content is loaded properly
         emptyStateContent.shouldNot(exist, Duration.ofSeconds(10));
 
-        item.click();
+        // Wait for the navigation item to be available before clicking
+        item.should(exist).shouldBe(interactable).click();
         toggleLeftSideBarIfOverlaysCamelTree();
     }
 

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/openshift/PodEntry.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/openshift/PodEntry.java
@@ -1,5 +1,6 @@
 package io.hawt.tests.features.pageobjects.fragments.openshift;
 
+import static com.codeborne.selenide.Condition.interactable;
 import static com.codeborne.selenide.Selenide.$;
 
 import org.apache.commons.lang3.NotImplementedException;
@@ -104,6 +105,6 @@ public class PodEntry {
     }
 
     public void connect() {
-        $(root).$(By.cssSelector(".pod-item-connect-button > button")).click();
+        $(root).$(By.cssSelector(".pod-item-connect-button > button")).shouldBe(interactable).click();
     }
 }

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/pages/HawtioPage.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/pages/HawtioPage.java
@@ -8,6 +8,7 @@ import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Condition.interactable;
 import static com.codeborne.selenide.Condition.matchText;
+import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byXpath;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
@@ -45,7 +46,7 @@ public class HawtioPage {
      * @param text on the given button
      */
     public HawtioPage clickButton(String text) {
-        $$(".pf-v6-c-button__text").findBy(exactText(text)).closest("button").shouldBe(clickable).click();
+        $$(".pf-v6-c-button__text").findBy(exactText(text)).closest("button").shouldBe(visible).shouldBe(enabled).click();
         return this;
     }
 
@@ -56,7 +57,7 @@ public class HawtioPage {
      * @return this
      */
     public HawtioPage clickToggleButton(String text) {
-        $$(".pf-v6-c-menu-toggle__text").findBy(matchText(text.trim())).closest("button").shouldBe(interactable).click();
+        $$(".pf-v6-c-menu-toggle__text").findBy(matchText(text.trim())).closest("button").shouldBe(visible).shouldBe(enabled).click();
         return this;
     }
 

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/camel/endpoints/CamelEndpointsStepDefs.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/stepdefinitions/camel/endpoints/CamelEndpointsStepDefs.java
@@ -68,4 +68,9 @@ public class CamelEndpointsStepDefs {
     public void detailsOfTheMessageWithBodAreDisplayed(String message) {
         camelBrowse.detailsAreDisplayed(message);
     }
+
+    @And("^User closes a Message details window$")
+    public void userClosesMessageDetailsWindow() {
+        camelBrowse.closeMessageDetailsWindow();
+    }
 }

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/v1/hawtiospec/Resources.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/v1/hawtiospec/Resources.java
@@ -9,13 +9,13 @@ public class Resources implements io.fabric8.kubernetes.api.model.KubernetesReso
      * Claims lists the names of resources, defined in spec.resourceClaims,
      * that are used by this container.
      *
-     * This is an alpha field and requires enabling the
+     * This field depends on the
      * DynamicResourceAllocation feature gate.
      *
      * This field is immutable. It can only be set for containers.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("claims")
-    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private java.util.List<io.hawt.v1.hawtiospec.resources.Claims> claims;
 

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/v1alpha1/hawtiospec/Resources.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/v1alpha1/hawtiospec/Resources.java
@@ -9,13 +9,13 @@ public class Resources implements io.fabric8.kubernetes.api.model.KubernetesReso
      * Claims lists the names of resources, defined in spec.resourceClaims,
      * that are used by this container.
      *
-     * This is an alpha field and requires enabling the
+     * This field depends on the
      * DynamicResourceAllocation feature gate.
      *
      * This field is immutable. It can only be set for containers.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("claims")
-    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private java.util.List<io.hawt.v1alpha1.hawtiospec.resources.Claims> claims;
 

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/v2/HawtioSpec.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/v2/HawtioSpec.java
@@ -1,7 +1,7 @@
 package io.hawt.v2;
 
 @com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
-@com.fasterxml.jackson.annotation.JsonPropertyOrder({"auth","config","externalRoutes","metadataPropagation","nginx","rbac","replicas","resources","route","routeHostName","type","version"})
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"auth","config","externalRoutes","healthChecks","logging","metadataPropagation","nginx","rbac","replicas","resources","route","routeHostName","type","version"})
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 public class HawtioSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
 
@@ -51,6 +51,38 @@ public class HawtioSpec implements io.fabric8.kubernetes.api.model.KubernetesRes
 
     public void setExternalRoutes(java.util.List<String> externalRoutes) {
         this.externalRoutes = externalRoutes;
+    }
+
+    /**
+     * The Hawtio health checking configuration
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("healthChecks")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The Hawtio health checking configuration")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private io.hawt.v2.hawtiospec.HealthChecks healthChecks;
+
+    public io.hawt.v2.hawtiospec.HealthChecks getHealthChecks() {
+        return healthChecks;
+    }
+
+    public void setHealthChecks(io.hawt.v2.hawtiospec.HealthChecks healthChecks) {
+        this.healthChecks = healthChecks;
+    }
+
+    /**
+     * The Hawtio logging configuration
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("logging")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The Hawtio logging configuration")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private io.hawt.v2.hawtiospec.Logging logging;
+
+    public io.hawt.v2.hawtiospec.Logging getLogging() {
+        return logging;
+    }
+
+    public void setLogging(io.hawt.v2.hawtiospec.Logging logging) {
+        this.logging = logging;
     }
 
     /**

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/v2/hawtiospec/HealthChecks.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/v2/hawtiospec/HealthChecks.java
@@ -1,0 +1,72 @@
+package io.hawt.v2.hawtiospec;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"gatewayLivenessPeriod","gatewayReadinessPeriod","onlineLivenessPeriod","onlineReadinessPeriod"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+public class HealthChecks implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    /**
+     * Configure the period, in seconds, between gateway container liveness probe checks
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("gatewayLivenessPeriod")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Configure the period, in seconds, between gateway container liveness probe checks")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private Integer gatewayLivenessPeriod;
+
+    public Integer getGatewayLivenessPeriod() {
+        return gatewayLivenessPeriod;
+    }
+
+    public void setGatewayLivenessPeriod(Integer gatewayLivenessPeriod) {
+        this.gatewayLivenessPeriod = gatewayLivenessPeriod;
+    }
+
+    /**
+     * Configure the period, in seconds, between gateway container readiness probe checks
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("gatewayReadinessPeriod")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Configure the period, in seconds, between gateway container readiness probe checks")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private Integer gatewayReadinessPeriod;
+
+    public Integer getGatewayReadinessPeriod() {
+        return gatewayReadinessPeriod;
+    }
+
+    public void setGatewayReadinessPeriod(Integer gatewayReadinessPeriod) {
+        this.gatewayReadinessPeriod = gatewayReadinessPeriod;
+    }
+
+    /**
+     * Configure the period, in seconds, between online container liveness probe checks
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("onlineLivenessPeriod")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Configure the period, in seconds, between online container liveness probe checks")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private Integer onlineLivenessPeriod;
+
+    public Integer getOnlineLivenessPeriod() {
+        return onlineLivenessPeriod;
+    }
+
+    public void setOnlineLivenessPeriod(Integer onlineLivenessPeriod) {
+        this.onlineLivenessPeriod = onlineLivenessPeriod;
+    }
+
+    /**
+     * Configure the period, in seconds, between online container readiness probe checks
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("onlineReadinessPeriod")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Configure the period, in seconds, between online container readiness probe checks")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private Integer onlineReadinessPeriod;
+
+    public Integer getOnlineReadinessPeriod() {
+        return onlineReadinessPeriod;
+    }
+
+    public void setOnlineReadinessPeriod(Integer onlineReadinessPeriod) {
+        this.onlineReadinessPeriod = onlineReadinessPeriod;
+    }
+}
+

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/v2/hawtiospec/Logging.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/v2/hawtiospec/Logging.java
@@ -1,0 +1,58 @@
+package io.hawt.v2.hawtiospec;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"gatewayLogLevel","maskIPAddresses","onlineLogLevel"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+public class Logging implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    /**
+     * Configure gateway log level {info|debug}
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("gatewayLogLevel")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Configure gateway log level {info|debug}")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String gatewayLogLevel;
+
+    public String getGatewayLogLevel() {
+        return gatewayLogLevel;
+    }
+
+    public void setGatewayLogLevel(String gatewayLogLevel) {
+        this.gatewayLogLevel = gatewayLogLevel;
+    }
+
+    /**
+     * Turn on/off the masking of IP addresses in logging {true|false} (off by default)
+     * Warning: this can cause issues if ip address are part of MBean Idenfifiers so
+     * use with caution.
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("maskIPAddresses")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Turn on/off the masking of IP addresses in logging {true|false} (off by default)\nWarning: this can cause issues if ip address are part of MBean Idenfifiers so\nuse with caution.")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String maskIPAddresses;
+
+    public String getMaskIPAddresses() {
+        return maskIPAddresses;
+    }
+
+    public void setMaskIPAddresses(String maskIPAddresses) {
+        this.maskIPAddresses = maskIPAddresses;
+    }
+
+    /**
+     * Configure online log level {emerg|alert|crit|error|warn|notice|info}
+     */
+    @com.fasterxml.jackson.annotation.JsonProperty("onlineLogLevel")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Configure online log level {emerg|alert|crit|error|warn|notice|info}")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String onlineLogLevel;
+
+    public String getOnlineLogLevel() {
+        return onlineLogLevel;
+    }
+
+    public void setOnlineLogLevel(String onlineLogLevel) {
+        this.onlineLogLevel = onlineLogLevel;
+    }
+}
+

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/v2/hawtiospec/Resources.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/v2/hawtiospec/Resources.java
@@ -9,13 +9,13 @@ public class Resources implements io.fabric8.kubernetes.api.model.KubernetesReso
      * Claims lists the names of resources, defined in spec.resourceClaims,
      * that are used by this container.
      *
-     * This is an alpha field and requires enabling the
+     * This field depends on the
      * DynamicResourceAllocation feature gate.
      *
      * This field is immutable. It can only be set for containers.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("claims")
-    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private java.util.List<io.hawt.v2.hawtiospec.resources.Claims> claims;
 

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/endpoints/camel_specific_endpoint.feature
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/camel/endpoints/camel_specific_endpoint.feature
@@ -66,3 +66,4 @@ Feature: Checking the functionality of a Camel Specific Endpoint page.
     And User clicks on Camel "Browse" tab
     When User clicks on the message with "Hello Test" body
     Then Details of the message with "Hello Test" body are displayed
+    And User closes a Message details window

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/panel/preferences/preferences.feature
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/features/panel/preferences/preferences.feature
@@ -22,6 +22,7 @@ Feature: Checking the functionality of a Preferences tab
     Examples:
       |Connect      |
 
+  @notOnline
   Scenario: Check that Home tab works
     Given User clicks on "Preferences" option in hawtio drop-down menu
     And User is on "Home" tab of Preferences page
@@ -50,7 +51,7 @@ Feature: Checking the functionality of a Preferences tab
     Then User confirms modal "clear-connections-modal" resetting with confirmation "You are about to clear all saved connection settings." and clicks reset button "[data-testid='clear-btn']"
     And User is presented with a successful alert message
 
-#  @notHawtioNext @notJBang
+#  @notOnline @notHawtioNext @notJBang
 #  Scenario: Check that Sample Plugin tab works
 #    Given User clicks on "Preferences" option in hawtio drop-down menu
 #    And User is on "Sample Plugin" tab of Preferences page


### PR DESCRIPTION
This PR is similar to https://github.com/hawtio/hawtio/pull/4231 but adapted for 5.x branch.

In this PR:
- New tests to check IP masking feature (Hawtio Online) when enabled and disabled;
- Updated CRD-s which are used by e2e online tests;
- Stabilized flaky tests related to operator testing;
- Disabled Plugin tests and Reset settings scenarios in Hawtio Online tests (they were causing issues);
- Improved some other test behaviours;