### PR TITLE
chore(quarkus): upgrade to Quarkus 3.32.1

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -25,9 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ["17"]
-        # Disable runtime "quarkus-keycloak" until Quarkus 3.31.2 is released
-        # https://github.com/quarkusio/quarkus/pull/52332
-        runtime: ["quarkus", "springboot"]
+        runtime: ["quarkus", "springboot", "quarkus-keycloak"]
         browser: ["firefox"] # chrome disabled because of https://github.com/hawtio/hawtio-next/issues/478
     env:
       REPORT_DIR: results-${{matrix.runtime}}-${{matrix.java}}-${{matrix.browser}}

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <jolokia-version>2.5.1</jolokia-version>
     <jolokia-integration-version>0.9.0</jolokia-integration-version>
     <!-- Quarkus -->
-    <quarkus-version>3.30.8</quarkus-version>
+    <quarkus-version>3.32.1</quarkus-version>
     <!-- Spring -->
     <!-- https://docs.spring.io/spring-boot/appendix/dependency-versions/coordinates.html -->
     <spring-version>6.2.16</spring-version>


### PR DESCRIPTION
Restores quarkus-keycloak E2E