### PR TITLE
[E2E] Refactor e2e workflow file to include keycloak.

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -25,10 +25,14 @@ jobs:
       fail-fast: false
       matrix:
         java: ["17"]
-        runtime: ["quarkus", "springboot", "quarkus-keycloak"]
+        runtime: ["quarkus", "springboot"]
+        auth: ["standard", "keycloak"]
         browser: ["firefox"] # chrome disabled because of https://github.com/hawtio/hawtio-next/issues/478
+        exclude:
+          - runtime: springboot
+            auth: keycloak
     env:
-      REPORT_DIR: results-${{matrix.runtime}}-${{matrix.java}}-${{matrix.browser}}
+      REPORT_DIR: results-${{matrix.runtime}}-${{matrix.auth}}-${{matrix.java}}-${{matrix.browser}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -48,13 +52,18 @@ jobs:
         uses: docker/setup-qemu-action@v3.6.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Set module name
+        id: runtime
+        run: |
+          # Module name is simply the runtime (auth is a separate configuration dimension)
+          echo "module=${{matrix.runtime}}" >> $GITHUB_ENV
       - name: Build Maven projects
         run: |
           # Phase 1: Build entire project to ensure all modules are fresh
           mvn --batch-mode --no-transfer-progress install -DskipTests
           # Phase 2: Build test modules with e2e profile to create app artifacts
           mvn --batch-mode --no-transfer-progress install -DskipTests \
-            -Pe2e -pl :hawtio-tests-${{matrix.runtime}} -am
+            -Pe2e -pl :hawtio-tests-${{ env.module }} -am
       - name: Build hawtio-test-suite image
         uses: docker/build-push-action@v6
         with:
@@ -66,24 +75,22 @@ jobs:
           load: true
           cache-from: type=gha,scope=hawtio-test-suite-${{ matrix.java }}
           cache-to: type=gha,mode=max,scope=hawtio-test-suite-${{ matrix.java }}
-      - name: Build hawtio-${{ matrix.runtime }}-app image
+      - name: Build hawtio-${{ env.module }}-app image
         uses: docker/build-push-action@v6
         with:
-          context: tests/${{ matrix.runtime }}
-          file: tests/${{ matrix.runtime }}/Dockerfile
+          context: tests/${{ env.module }}
+          file: tests/${{ env.module }}/Dockerfile
           build-args: |
             JAVA_VERSION=${{ matrix.java }}
-          tags: hawtio-${{ matrix.runtime }}-app:${{ matrix.java }}
+          tags: hawtio-${{ env.module }}-app:${{ matrix.java }}
           load: true
-          cache-from: type=gha,scope=${{ matrix.runtime }}-app-${{ matrix.java }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.runtime }}-app-${{ matrix.java }}
-      - name: ${{ matrix.runtime }} E2E test (Java ${{ matrix.java }})
+          cache-from: type=gha,scope=${{ env.module }}-app-${{ matrix.java }}
+          cache-to: type=gha,mode=max,scope=${{ env.module }}-app-${{ matrix.java }}
+      - name: ${{ matrix.runtime }}-${{ matrix.auth }} E2E test (Java ${{ matrix.java }})
         id: test
         run: |
-          runtime=${{matrix.runtime}}
           extra_args=''
-          if [[ $runtime =~ "-keycloak" ]]; then
-            runtime=${runtime%-keycloak}
+          if [[ "${{ matrix.auth }}" == "keycloak" ]]; then
             extra_args='-Dio.hawt.test.use.keycloak=true'
           fi
           docker run --rm \
@@ -91,13 +98,13 @@ jobs:
           -v $PWD/$REPORT_DIR:/workspace/tests/hawtio-test-suite/target \
           -v $PWD/$REPORT_DIR/build:/workspace/tests/hawtio-test-suite/build/ \
           --shm-size="2g" \
-            hawtio-test-suite:${{ matrix.java }} -Pe2e-${runtime} -Dselenide.browser=${{ matrix.browser }} \
-            -Dio.hawt.test.docker.image=hawtio-${runtime}-app:${{ matrix.java }} $extra_args
+            hawtio-test-suite:${{ matrix.java }} -Pe2e-${{ matrix.runtime }} -Dselenide.browser=${{ matrix.browser }} \
+            -Dio.hawt.test.docker.image=hawtio-${{ matrix.runtime }}-app:${{ matrix.java }} $extra_args
       - name: Archive test artifacts
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "test-results-${{ matrix.runtime }}-java-${{ matrix.java }}-${{ matrix.browser }}"
+          name: "test-results-${{ matrix.runtime }}-${{ matrix.auth }}-java-${{ matrix.java }}-${{ matrix.browser }}"
           path: |
             ${{ env.REPORT_DIR }}/build/reports/tests/*.png
             ${{ env.REPORT_DIR }}/*.log

--- a/tests/quarkus/src/main/docker/Dockerfile.jvm
+++ b/tests/quarkus/src/main/docker/Dockerfile.jvm
@@ -81,6 +81,8 @@ FROM ${IMAGE}:${JAVA_VERSION}
 
 ENV LANGUAGE='en_US:en'
 
+# Install zip utilities needed for Keycloak config patching
+RUN apt-get update && apt-get install -y zip unzip && rm -rf /var/lib/apt/lists/*
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/

--- a/tests/quarkus/start-keycloak.sh
+++ b/tests/quarkus/start-keycloak.sh
@@ -1,9 +1,61 @@
 #!/usr/bin/env bash
+set -e
 
-cd /tmp
-jar xf /deployments/app/*.jar keycloak-hawtio.json
-sed -i s,http://localhost:18080,$KEYCLOAK_URL, keycloak-hawtio.json
-jar uf  /deployments/app/*.jar keycloak-hawtio.json
-java -Dquarkus.profile=keycloak -Dquarkus.launch.rebuild=true -jar ${JAVA_APP_JAR}
-echo "Running: java -jar ${JAVA_OPTS} -Dquarkus.oidc.auth-server-url=$KEYCLOAK_URL/realms/hawtio-demo ${JAVA_APP_JAR}"
-java -jar ${JAVA_OPTS} -Dquarkus.oidc.auth-server-url=$KEYCLOAK_URL/realms/hawtio-demo ${JAVA_APP_JAR}
+# 1. Use mktemp to create an isolated directory, avoiding:
+# - Zombie processes holding file locks in shared /tmp
+# - Permission/sticky bit issues from previous runs
+# - Collisions with parallel test executions
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+cd "$WORK_DIR"
+
+echo "Patching Hawtio Keycloak in isolated directory: $WORK_DIR"
+
+# 2. Find and Extract
+APP_JAR=$(ls /deployments/app/*.jar 2>/dev/null | head -n 1)
+if [ -z "$APP_JAR" ]; then
+    echo "ERROR: No JAR files found in /deployments/app/"
+    exit 1
+fi
+
+# Use -j (junk paths) to extract just the file without directory structure
+# This avoids creating META-INF or any other directories
+unzip -q -j ${APP_JAR} keycloak-hawtio.json
+
+if [ ! -f "keycloak-hawtio.json" ]; then
+    echo "ERROR: keycloak-hawtio.json not found in ${APP_JAR}!"
+    exit 1
+fi
+
+# 3. Patch and Verify
+if [ -z "$KEYCLOAK_URL" ]; then
+    echo "ERROR: KEYCLOAK_URL not set!"
+    exit 1
+fi
+
+sed -i "s|http://localhost:18080|$KEYCLOAK_URL|g" keycloak-hawtio.json
+
+if ! grep -q "$KEYCLOAK_URL" keycloak-hawtio.json; then
+    echo "ERROR: Patching failed! URL not found in JSON."
+    exit 1
+fi
+
+# 4. Inject using ZIP
+# zip is more predictable than jar uf - it just updates the bits without
+# trying to validate Java-specific metadata that causes ZipException
+echo "Injecting patched config back into JAR using zip..."
+zip -q ${APP_JAR} keycloak-hawtio.json
+
+# 5. Execute with Re-augmentation (Two-Phase Startup)
+# Phase 1: Augment with Keycloak enabled (this will exit after rebuild)
+echo "Phase 1: Re-augmenting Quarkus with Keycloak profile..."
+java -Dquarkus.profile=keycloak \
+  -Dquarkus.launch.rebuild=true \
+  -jar /deployments/quarkus-run.jar
+
+# Phase 2: Start the server with the re-augmented config
+echo "Phase 2: Starting Quarkus server..."
+exec java ${JAVA_OPTS} \
+  -Dquarkus.profile=keycloak \
+  -Dquarkus.oidc.auth-server-url=$KEYCLOAK_URL/realms/hawtio-demo \
+  -jar /deployments/quarkus-run.jar


### PR DESCRIPTION
This PR:

- Refactor of E2E workflow file to correctly use keycloak as configuration and not as a runtime;
- Refactor the start-keycloak script
  - to prevent two keycloak instances which led to two Keycloak buttons on the Hawtio login page instead of a redirection to the Keycloak login page;
  - Fixed various errors and issues like ZipException, Container exit issues and Build-time property warnings;

The successful run was done in my forked project - https://github.com/jsolovjo/hawtio/actions/runs/22644585381