### PR TITLE
[E2E] Fix quarkus keycloak tests.

### DIFF
--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/pages/LoginPage.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/pages/LoginPage.java
@@ -11,6 +11,7 @@ import static com.codeborne.selenide.Condition.editable;
 import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
 
 /**
@@ -21,7 +22,7 @@ public class LoginPage {
     private final static SelenideElement loginInput = $("#pf-login-username-id");
     private final static SelenideElement passwordInput = $("#pf-login-password-id");
     private final static SelenideElement loginButton = $("button[type='submit']");
-
+    private final static SelenideElement keycloakButton = $(byText("Keycloak"));
 
     /**
      * Login to hawtio as given user with given password.
@@ -48,5 +49,12 @@ public class LoginPage {
         loginInput.shouldBe(editable).should(exist);
         passwordInput.shouldBe(editable);
         loginButton.shouldBe(enabled);
+    }
+
+    /**
+     * Click the Keycloak identity provider button to redirect to Keycloak login
+     */
+    public void clickKeycloakButton() {
+        keycloakButton.shouldBe(visible).shouldBe(enabled).click();
     }
 }

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/LoginLogout.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/LoginLogout.java
@@ -68,7 +68,9 @@ public class LoginLogout {
     }
 
     private static void keycloakLogin(String username, String password) {
-        Selenide.open(DeployAppHook.getBaseURL() + TestConfiguration.getUrlSuffix() + "/connect");
+        LoginPage loginPage = Selenide.open(DeployAppHook.getBaseURL() + TestConfiguration.getUrlSuffix() + "/connect", LoginPage.class);
+        loginPage.clickKeycloakButton();
+
         Selenide.$(By.id("username")).sendKeys(username);
         Selenide.$(By.id("password")).sendKeys(password);
 

--- a/tests/quarkus/src/main/resources/application-keycloak.properties
+++ b/tests/quarkus/src/main/resources/application-keycloak.properties
@@ -6,6 +6,9 @@ quarkus.hawtio.keycloakClientConfig = classpath:keycloak-hawtio.json
 
 #
 # Quarkus OIDC configuration for Keycloak
+# Note: OIDC is enabled for backend token validation, but path protection is disabled
+# to allow Hawtio to show its login page with the "Keycloak" button instead of
+# directly redirecting to Keycloak. Hawtio's JavaScript handles the authentication flow.
 #
 quarkus.oidc.enabled=true
 #quarkus.oidc.auth-server-url = http://localhost:18080/realms/hawtio-demo
@@ -13,8 +16,12 @@ quarkus.oidc.client-id = hawtio-client
 quarkus.oidc.credentials.secret = secret
 quarkus.oidc.application-type = web-app
 quarkus.oidc.token-state-manager.split-tokens = true
-quarkus.http.auth.permission.authenticated.paths = /*
-quarkus.http.auth.permission.authenticated.policy = authenticated
+
+# Path protection is DISABLED to let Hawtio handle the login flow
+# If enabled, Quarkus OIDC would redirect directly to Keycloak before Hawtio's UI loads
+#quarkus.http.auth.permission.authenticated.paths = /*
+#quarkus.http.auth.permission.authenticated.policy = authenticated
+
 quarkus.security.users.embedded.enabled = false
 
 quarkus.keycloak.devservices.enabled=false


### PR DESCRIPTION
This PR:
- Fixes the tests related to Quarkus with Keycloak;
- Before, it got redirected directly to the Keycloak page skipping the Hawtio page with selection of providers such as Keycloak which is the wrong behaviour;
- Now it first opens Hawtio, selects Keycloak and then gets redirected to the Keycloak page;

There was a bug with two Keycloak buttons and broken functionality, it's fixed by - https://github.com/hawtio/hawtio-react/commit/d27b80f00972d257b9532a22d86af04b45512ce9
