### PR TITLE
Upgrade to xtf 1.0 version

### DIFF
--- a/tests/hawtio-test-suite/pom.xml
+++ b/tests/hawtio-test-suite/pom.xml
@@ -16,7 +16,7 @@
     <local-app>true</local-app>
     <egit-github-core-version>2.1.5</egit-github-core-version>
     <gson-version>2.13.2</gson-version>
-    <xtf.version>0.37</xtf.version>
+    <xtf.version>1.0</xtf.version>
   </properties>
 
   <dependencyManagement>

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/HawtioOnlineUtils.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/HawtioOnlineUtils.java
@@ -25,7 +25,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;
-import io.fabric8.openshift.api.model.operatorhub.lifecyclemanager.v1.PackageManifest;
+import io.fabric8.openshift.api.model.operatorhub.packages.v1.PackageManifest;
 import io.fabric8.openshift.api.model.operatorhub.v1.OperatorGroupBuilder;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.CatalogSource;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.CatalogSourceBuilder;

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/OpenshiftClient.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/OpenshiftClient.java
@@ -26,38 +26,45 @@ public class OpenshiftClient extends OpenShift {
     }
 
     private static OpenshiftClient createInstance() {
-        OpenShiftConfigBuilder configBuilder;
+        OpenShiftConfig openShiftConfig;
 
         if (TestConfiguration.getOpenshiftUrl() != null) {
-            configBuilder = new OpenShiftConfigBuilder()
+            openShiftConfig = new OpenShiftConfigBuilder()
                 .withMasterUrl(TestConfiguration.getOpenshiftUrl())
                 .withUsername(TestConfiguration.getOpenshiftUsername())
-                .withPassword(TestConfiguration.getOpenshiftPassword());
+                .withPassword(TestConfiguration.getOpenshiftPassword())
+                .withNamespace(TestConfiguration.getOpenshiftNamespace())
+                .withBuildTimeout(60_000L)
+                .withRequestTimeout(120_000)
+                .withConnectionTimeout(120_000)
+                .withTrustCerts(true)
+                .build();
         } else if (TestConfiguration.openshiftKubeconfig() != null) {
             try {
-                configBuilder = new OpenShiftConfigBuilder(
-                    new OpenShiftConfig(Config.fromKubeconfig(IOUtils.toString(TestConfiguration.openshiftKubeconfig().toUri(), "UTF-8"))));
+                Config config = Config.fromKubeconfig(IOUtils.toString(TestConfiguration.openshiftKubeconfig().toUri(), "UTF-8"));
+                openShiftConfig = new OpenShiftConfig(config);
+                openShiftConfig.setNamespace(TestConfiguration.getOpenshiftNamespace());
+                openShiftConfig.setBuildTimeout(60_000L);
+                openShiftConfig.setRequestTimeout(120_000);
+                openShiftConfig.setConnectionTimeout(120_000);
+                openShiftConfig.setTrustCerts(true);
             } catch (IOException e) {
                 throw new RuntimeException("Unable to read kubeconfig", e);
             }
         } else {
             LOG.info("Auto-configuring openshift client");
-            configBuilder = new OpenShiftConfigBuilder(new OpenShiftConfig(Config.autoConfigure(null)));
+            Config config = Config.autoConfigure(null);
+            openShiftConfig = new OpenShiftConfig(config);
+            openShiftConfig.setNamespace(TestConfiguration.getOpenshiftNamespace());
+            openShiftConfig.setBuildTimeout(60_000L);
+            openShiftConfig.setRequestTimeout(120_000);
+            openShiftConfig.setConnectionTimeout(120_000);
+            openShiftConfig.setTrustCerts(true);
         }
 
-        String namespace = TestConfiguration.getOpenshiftNamespace();
+        LOG.info("Using cluster {}", openShiftConfig.getMasterUrl());
 
-        configBuilder
-            .withNamespace(namespace)
-//            .withHttpsProxy(TestConfiguration.openshiftHttpsProxy())
-            .withBuildTimeout(60_000L)
-            .withRequestTimeout(120_000)
-            .withConnectionTimeout(120_000)
-            .withTrustCerts(true);
-
-        LOG.info("Using cluster {}", configBuilder.getMasterUrl());
-
-        return new OpenshiftClient(configBuilder.build());
+        return new OpenshiftClient(openShiftConfig);
     }
 
     private static OpenshiftClient init() {


### PR DESCRIPTION
Due to the **xtf** framework updating to version **1.0**, important changes include: 

- PackageManifest model changes
- New Fabric8 config/client APIs (OpenshiftClient.java now relies on more explicit set up config)

Did a test run on QE jenkins, the set up goes smoothly; tests fail due to the usage of the old operator.