### PR TITLE
task: do not execute SessionExpiryFilter for every call

### DIFF
--- a/hawtio-system/src/main/java/io/hawt/web/auth/SessionExpiryFilter.java
+++ b/hawtio-system/src/main/java/io/hawt/web/auth/SessionExpiryFilter.java
@@ -39,8 +39,6 @@ public class SessionExpiryFilter implements Filter {
 
     public static final String ATTRIBUTE_LAST_ACCESS = "LastAccess";
 
-    private static final List<String> IGNORED_PATHS = List.of("jolokia", "proxy");
-
     private AuthenticationConfiguration authConfiguration;
     private int pathIndex;
 
@@ -128,11 +126,8 @@ public class SessionExpiryFilter implements Filter {
         }
 
         LOG.debug("SubContext: {}", subContext);
-        if (IGNORED_PATHS.contains(subContext) && session.getAttribute(ATTRIBUTE_LAST_ACCESS) != null) {
-            LOG.debug("Not updating LastAccess");
-        } else {
-            updateLastAccess(session, now);
-        }
+
+        updateLastAccess(session, now);
 
         chain.doFilter(request, response);
     }

--- a/platforms/springboot/src/main/java/io/hawt/springboot/HawtioManagementConfiguration.java
+++ b/platforms/springboot/src/main/java/io/hawt/springboot/HawtioManagementConfiguration.java
@@ -183,7 +183,7 @@ public class HawtioManagementConfiguration {
     public FilterRegistrationBean<SessionExpiryFilter> sessionExpiryFilter() {
         final FilterRegistrationBean<SessionExpiryFilter> filter = new FilterRegistrationBean<>();
         filter.setFilter(new SessionExpiryFilter());
-        filter.addUrlPatterns(hawtioPath + "/*");
+        filter.addUrlPatterns(hawtioPath + "/refresh");
         return filter;
     }
 


### PR DESCRIPTION
I'm submitting this for v4.x only for now.

I was profiling some code and I noticed hawtio's SessionExpiryFilter.doFilter uses a very big amount of CPU compared to other methods. I was testing this inside apache artemis web console. While the broker was idle, and the webpage refreshes were the only thing using CPU, SessionExpiryFilter used 50% of cpu time.

<img width="1897" height="511" alt="image" src="https://github.com/user-attachments/assets/9e30b5a6-06bc-41bf-9a09-a269d07d5e2b" />

I realized this filter does some "work" for every call - even for static files.
(only) after that, it filters out _IGNORED_PATHS_.

I don't think executing this for every file/call is the correct way to approach this.

I wasn't sure know which URL patterns should implement SessionExpiryFilter - but for v4, at least, I came to the conclusion that "refresh" calls are the only (and a very good) indicator if a user is "active" on the webpage.

Tested latest v4 only, through artemis. Session expiry behaves as expected. Results:

<img width="1934" height="600" alt="image" src="https://github.com/user-attachments/assets/dd42a7de-ce24-48be-af52-cb0796f995db" />

Let me know what you think ...