### PR TITLE
[E2E] Fix report dir paths for jbang in 4.x-redhat.

### DIFF
--- a/.github/workflows/jbang-test.yml
+++ b/.github/workflows/jbang-test.yml
@@ -78,8 +78,8 @@ jobs:
         run: |
           mkdir -p $PWD/$REPORT_DIR/
           docker run --rm --network host \
-            -v $PWD/$REPORT_DIR:/hawtio-test-suite/tests/hawtio-test-suite/target \
-            -v $PWD/$REPORT_DIR/build:/hawtio-test-suite/tests/hawtio-test-suite/build/ \
+            -v $PWD/$REPORT_DIR:/workspace/tests/hawtio-test-suite/target \
+            -v $PWD/$REPORT_DIR/build:/workspace/tests/hawtio-test-suite/build/ \
             --shm-size="2g" \
             hawtio-test-suite:${{matrix.java}} \
               -Pe2e-${{ matrix.runtime }} -Dselenide.browser=firefox \


### PR DESCRIPTION
Fix report dir paths for jbang in 4.x-redhat