### PR TITLE
[E2E] Add new operator namespace watching tests.

### DIFF
--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/HawtioOnlineUtils.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/HawtioOnlineUtils.java
@@ -437,12 +437,16 @@ public class HawtioOnlineUtils {
     }
 
     public static String deployHawtioCR(Hawtio hawtio) {
+        final String namespace = hawtio.getMetadata().getNamespace();
+        final String hawtioCrName = hawtio.getMetadata().getName();
         hawtio.getMetadata().getFinalizers().clear();
-        OpenshiftClient.get().resources(Hawtio.class).createOrReplace(hawtio);
+
+        OpenshiftClient.get().resources(Hawtio.class).inNamespace(namespace).createOrReplace(hawtio);
 
         WaitUtils.waitFor(() -> {
             final Resource<Hawtio> resource = OpenshiftClient.get().resources(Hawtio.class)
-                .withName(hawtio.getMetadata().getName());
+                .inNamespace(namespace)
+                .withName(hawtioCrName);
             final Hawtio hawtioResource = resource.get();
             return resource.isReady() &&
                 hawtioResource.getStatus() != null &&
@@ -451,8 +455,7 @@ public class HawtioOnlineUtils {
                 hawtioResource.getStatus().getURL() != null;
         }, "Waiting for hawtio deployment to succeed", Duration.ofMinutes(2));
 
-        return OpenshiftClient.get().resources(Hawtio.class).withName(hawtio.getMetadata().getName()).get().getStatus()
-            .getURL();
+        return OpenshiftClient.get().resources(Hawtio.class).inNamespace(namespace).withName(hawtioCrName).get().getStatus().getURL();
     }
 
     public static String deployNamespacedHawtio(String name, String namespace) {
@@ -481,14 +484,16 @@ public class HawtioOnlineUtils {
     public static void patchHawtioResource(String name, Consumer<Hawtio> action) {
         WaitUtils.withRetry(() -> {
             final Hawtio hawtio = OpenshiftClient.get().resources(Hawtio.class).withName(name).get();
+            final String namespace = hawtio.getMetadata().getNamespace();
             action.accept(hawtio);
-            OpenshiftClient.get().resources(Hawtio.class).withName(name).patch(hawtio);
+            OpenshiftClient.get().resources(Hawtio.class).inNamespace(namespace).withName(name).patch(hawtio);
         }, 5, Duration.ofMillis(500));
     }
 
     public static void patchHawtioResource(String name, Hawtio value) {
         WaitUtils.withRetry(() -> {
-            OpenshiftClient.get().resources(Hawtio.class).withName(name).patch(value);
+            final String namespace = value.getMetadata().getNamespace();
+            OpenshiftClient.get().resources(Hawtio.class).inNamespace(namespace).withName(name).patch(value);
         }, 5, Duration.ofMillis(500));
     }
 

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/common/CamelOperations.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/camel/tabs/common/CamelOperations.java
@@ -7,7 +7,6 @@ import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byAttribute;
-import static com.codeborne.selenide.Selectors.byTagAndText;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.TextMatchOptions.partialText;
 
@@ -23,7 +22,7 @@ import com.codeborne.selenide.WebElementCondition;
 public class CamelOperations extends CamelPage {
 
     private static final By EXPAND_BUTTON_SELECTOR = byAttribute( "aria-label", "Details");
-    private static final By EXECUTE_BUTTON_SELECTOR = byTagAndText("span", "Execute");
+    private static final By EXECUTE_BUTTON_SELECTOR = By.xpath(".//button[contains(., 'Execute')]");
     private static final By RESULT_PRE_SELECTOR = By.tagName("pre");
     private static final By DISABLED_ICON_SELECTOR = By.cssSelector(".pf-v6-c-data-list__item-content svg");
 

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/online/DiscoverTab.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/online/DiscoverTab.java
@@ -1,5 +1,7 @@
 package io.hawt.tests.features.pageobjects.fragments.online;
 
+import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Selectors.byTagName;
 import static com.codeborne.selenide.Selenide.$;
 
 import org.apache.commons.lang3.StringUtils;
@@ -63,7 +65,7 @@ public class DiscoverTab {
 
     public Map<String, DeploymentEntry> getDeployments() {
         waitForPageLoaded();
-        return $(ACTIVE_DEPLOYMENT_LIST).$$(By.tagName("dt")).asFixedIterable().stream().map(DeploymentEntry::new)
+        return $(ACTIVE_DEPLOYMENT_LIST).$$(byTagName("dt")).asFixedIterable().stream().map(DeploymentEntry::new)
             .collect(Collectors.toMap(DeploymentEntry::getName, d -> d));
     }
 
@@ -73,8 +75,9 @@ public class DiscoverTab {
     }
 
     public void selectNamespace(String namespace) {
+        waitForPageLoaded();
         final SelenideElement namespaceTab = $(DISCOVER_TABS).$(ByUtils.byPartialText(namespace));
-        namespaceTab.should(Condition.exist, Duration.ofMinutes(1));
+        namespaceTab.should(exist, Duration.ofSeconds(10));
         if (namespaceTab.is(Condition.interactable)) {
             namespaceTab.click();
         }
@@ -113,7 +116,7 @@ public class DiscoverTab {
     }
 
     private void waitForPageLoaded() {
-        $(ByUtils.byDataTestId("loading")).shouldNot(Condition.exist, Duration.ofSeconds(30));
-        $(ACTIVE_DEPLOYMENT_LIST).should(Condition.exist, Duration.ofSeconds(30));
+        $(ByUtils.byDataTestId("loading")).shouldNot(exist, Duration.ofSeconds(30));
+        $(ACTIVE_DEPLOYMENT_LIST).should(exist, Duration.ofSeconds(30));
     }
 }

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/pages/HawtioPage.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/pages/HawtioPage.java
@@ -9,6 +9,8 @@ import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Condition.interactable;
 import static com.codeborne.selenide.Condition.matchText;
 import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selectors.byClassName;
+import static com.codeborne.selenide.Selectors.byTagName;
 import static com.codeborne.selenide.Selectors.byXpath;
 import static com.codeborne.selenide.Selectors.byTagAndText;
 import static com.codeborne.selenide.Selenide.$;
@@ -22,8 +24,8 @@ import com.codeborne.selenide.SelenideElement;
  * Represents Hawtio page with common methods.
  */
 public class HawtioPage {
-
-    private static final By HEADER_SELECTOR = By.id("hawtio-header-brand");
+    private static final By HAWTIO_HEADER_SELECTOR = By.id("hawtio-header");
+    private static final By HAWTIO_HEADER_BRAND_SELECTOR = By.id("hawtio-header-brand");
 
     private final Menu menu;
     private final Panel panel;
@@ -124,11 +126,11 @@ public class HawtioPage {
     }
 
     public SelenideElement getLogo() {
-        return $(HEADER_SELECTOR).$(By.className("pf-v6-c-brand"));
+        return $(HAWTIO_HEADER_BRAND_SELECTOR).$(byClassName("pf-v6-c-brand"));
     }
 
     public String getAppName() {
-        return $(HEADER_SELECTOR).$(By.tagName("h1")).text();
+        return $(HAWTIO_HEADER_SELECTOR).$(byTagName("h1")).text();
     }
 
     /**

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/ClusterDiscoveryTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/ClusterDiscoveryTest.java
@@ -39,11 +39,13 @@ public class ClusterDiscoveryTest extends BaseHawtioOnlineTest {
 
     @AfterAll
     public static void cleanup() {
-        OpenshiftClient.get().resources(Hawtio.class).withName(CLUSTER_HAWTIO_NAME).delete();
+        OpenshiftClient.get().resources(Hawtio.class)
+            .inNamespace(TestConfiguration.getOpenshiftNamespace())
+            .withName(CLUSTER_HAWTIO_NAME).delete();
     }
 
     @Test
-    public void basicTest() {
+    public void testClusterModeDiscoversCrossNamespaceApps() {
         final String namespace = "e2e-discover-namespace-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
 
         HawtioOnlineTestUtils.withCleanup(() -> {

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/HawtioOperatorTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/HawtioOperatorTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.apache.commons.io.IOUtils;
@@ -123,7 +122,6 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
         Config config = new Config();
         runTest(s -> {
             About about = new About();
-            about.setImgSrc("https://i1.sndcdn.com/artworks-zyYqA8D0BdfuyH28-WeeHrw-t500x500.jpg");
             about.setTitle("MeowIO About");
             about.setAdditionalInfo("Hello world");
             final ProductInfo productInfo = new ProductInfo();
@@ -135,7 +133,6 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
             config.setAbout(about);
 
             Branding branding = new Branding();
-            branding.setAppLogoUrl("https://i1.sndcdn.com/artworks-zyYqA8D0BdfuyH28-WeeHrw-t500x500.jpg");
             branding.setAppName("MeowIO");
 
             config.setBranding(branding);
@@ -150,16 +147,12 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
 
             hawtio.panel().openMenuItemUnderQuestionMarkDropDownMenu("About");
             var aboutPanel = new AboutModalWindow();
-            sa.assertThat(aboutPanel.getBrandImage().getAttribute("src")).isEqualTo(config.getAbout().getImgSrc());
-            sa.assertThat(aboutPanel.getBrandImage().getAttribute("alt")).isEqualTo(config.getAbout().getTitle());
 
             sa.assertThat(aboutPanel.getAppComponents()).containsEntry("Testsuite", "latest");
             sa.assertThat(aboutPanel.getHeaderText()).isEqualTo(config.getAbout().getTitle());
             aboutPanel.close();
 
             sa.assertThat(hawtio.getAppName()).isEqualTo(config.getBranding().getAppName());
-            sa.assertThat(hawtio.getLogo().getAttribute("src")).isEqualTo(config.getBranding().getAppLogoUrl());
-            sa.assertThat(hawtio.getLogo().getAttribute("alt")).isEqualTo(config.getBranding().getAppName());
         });
     }
 
@@ -341,52 +334,76 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
         }, false);
     }
 
-    @Disabled("HAWNG-1863 due to operator bug: Operator fails to find RBAC ConfigMap with cache sync issue")
     @Test
     public void testRBAC() throws IOException {
-        OpenshiftClient.get().resource(new ConfigMapBuilder()
-            .withNewMetadata()
-            .withName("rbac-test")
-            .withNamespace(TestConfiguration.getOpenshiftNamespace())
-            .endMetadata()
-            .addToData("ACL.yaml", IOUtils.toString(getClass().getResource("/io/hawt/tests/openshift/acl.yaml"), StandardCharsets.UTF_8))
-            .build()
-        ).serverSideApply();
+        final String configMapName = "rbac-test-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
+        final String namespace = TestConfiguration.getOpenshiftNamespace();
 
-        runTest(spec -> {
-            var rbac = new Rbac();
-            rbac.setConfigMap("rbac-test");
-            spec.setRbac(rbac);
-        }, sa -> {
+        try {
+            // Create ConfigMap
+            OpenshiftClient.get().resource(new ConfigMapBuilder()
+                .withNewMetadata()
+                .withName(configMapName)
+                .withNamespace(namespace)
+                .endMetadata()
+                .addToData("ACL.yaml", IOUtils.toString(getClass().getResource("/io/hawt/tests/openshift/acl.yaml"), StandardCharsets.UTF_8))
+                .build()
+            ).serverSideApply();
 
-            var discoverTab = new DiscoverTab();
-            discoverTab.assertContainsDeployment(deployment.getMetadata().getName());
-            discoverTab.connectTo(podName);
+            // Wait for ConfigMap to be available and give operator cache time to sync
+            WaitUtils.waitFor(() ->
+                OpenshiftClient.get().configMaps()
+                    .inNamespace(namespace)
+                    .withName(configMapName)
+                    .get() != null,
+                "Waiting for RBAC ConfigMap to be created", Duration.ofSeconds(10));
 
-            LoginLogout.hawtioIsLoaded();
-            var hawtio = new HawtioPage();
+            runTest(spec -> {
+                var rbac = new Rbac();
+                rbac.setConfigMap(configMapName);
+                spec.setRbac(rbac);
+            }, sa -> {
 
-            hawtio.menu().navigateTo("Camel");
-            final CamelPage camelPage = new CamelPage();
+                var discoverTab = new DiscoverTab();
+                discoverTab.assertContainsDeployment(deployment.getMetadata().getName());
+                discoverTab.connectTo(podName);
 
-            camelPage.tree().selectSpecificItem("CamelContexts-folder-SampleCamel-folder");
-            camelPage.openTab("Operations");
+                LoginLogout.hawtioIsLoaded();
+                var hawtio = new HawtioPage();
 
-            final CamelOperations camelOperations = new CamelOperations();
-            camelOperations.checkOperation("stop()", Condition.disabled);
-            camelOperations.checkOperation("getTotalRoutes()", Condition.enabled);
+                hawtio.menu().navigateTo("Camel");
+                final CamelPage camelPage = new CamelPage();
 
-            hawtio.panel().logout();
-            new HawtioOnlineLoginPage().login("viewer", "viewer");
+                camelPage.tree().selectSpecificItem("CamelContexts-SampleCamel-folder");
+                camelPage.openTab("Operations");
 
-            LoginLogout.hawtioIsLoaded();
-            camelPage.tree().selectSpecificItem("CamelContexts-folder-SampleCamel-folder");
-            camelPage.openTab("Operations");
+                final CamelOperations camelOperations = new CamelOperations();
+                // stop() is denied for all roles (ACL: stop: [])
+                camelOperations.checkOperation("stop()", Condition.disabled);
+                // getTotalRoutes() falls to default rule allowing admin
+                camelOperations.checkOperation("getTotalRoutes()", Condition.enabled);
 
-            camelOperations.checkOperation("stop()", Condition.disabled);
-            camelOperations.checkOperation("restart()", Condition.disabled);
-            camelOperations.checkOperation("getTotalRoutes()", Condition.enabled);
-        });
+                hawtio.panel().logout();
+                new HawtioOnlineLoginPage().login("viewer", "viewer");
+
+                LoginLogout.hawtioIsLoaded();
+                camelPage.tree().selectSpecificItem("CamelContexts-SampleCamel-folder");
+                camelPage.openTab("Operations");
+
+                // stop() is denied for all roles (ACL: stop: [])
+                camelOperations.checkOperation("stop()", Condition.disabled);
+                // restart() is admin-only (ACL: restart: admin)
+                camelOperations.checkOperation("restart()", Condition.disabled);
+                // getTotalRoutes() falls to wildcard (org.apache.camel: /.*/: admin, viewer), viewer CAN execute
+                camelOperations.checkOperation("getTotalRoutes()", Condition.enabled);
+            });
+        } finally {
+            // Cleanup ConfigMap
+            OpenshiftClient.get().configMaps()
+                .inNamespace(namespace)
+                .withName(configMapName)
+                .delete();
+        }
     }
 
     @Test
@@ -487,13 +504,17 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
 
             // Wait for update to be processed
             WaitUtils.waitFor(() -> {
-                Hawtio h = OpenshiftClient.get().resources(Hawtio.class).withName(hawtio.getMetadata().getName()).get();
+                Hawtio h = OpenshiftClient.get().resources(Hawtio.class)
+                    .inNamespace(hawtio.getMetadata().getNamespace())
+                    .withName(hawtio.getMetadata().getName()).get();
                 return h.getSpec().getLogging() != null && h.getSpec().getLogging().getOnlineLogLevel() != null;
             }, "Waiting for CR update to be applied", Duration.ofSeconds(30));
 
             // Verify all logging properties are preserved after update
             SoftAssertions sa = new SoftAssertions();
-            Hawtio updatedHawtio = OpenshiftClient.get().resources(Hawtio.class).withName(hawtio.getMetadata().getName()).get();
+            Hawtio updatedHawtio = OpenshiftClient.get().resources(Hawtio.class)
+                .inNamespace(hawtio.getMetadata().getNamespace())
+                .withName(hawtio.getMetadata().getName()).get();
 
             sa.assertThat(updatedHawtio.getSpec().getLogging())
                 .as("Logging configuration should be present")

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/NamespacedDiscoveryTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/NamespacedDiscoveryTest.java
@@ -59,7 +59,7 @@ public class NamespacedDiscoveryTest extends BaseHawtioOnlineTest {
     }
 
     @Test
-    public void testNamespaceRestriction() {
+    public void testNamespacedModeIgnoresOtherNamespaceApps() {
         final String namespace = "hawtio-discover-test-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
         final String deploymentName = "hawtio-discover-test";
         HawtioOnlineTestUtils.withCleanup(() -> {

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/OperatorNamespaceWatchingTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/OperatorNamespaceWatchingTest.java
@@ -1,0 +1,400 @@
+package io.hawt.tests.openshift;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.assertj.core.api.SoftAssertions;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.openshift.api.model.operatorhub.v1alpha1.Subscription;
+import io.fabric8.openshift.api.model.operatorhub.v1alpha1.SubscriptionConfig;
+import io.hawt.tests.features.openshift.HawtioOnlineUtils;
+import io.hawt.tests.features.openshift.OpenshiftClient;
+import io.hawt.tests.features.openshift.WaitUtils;
+import io.hawt.tests.openshift.utils.BaseHawtioOnlineTest;
+import io.hawt.tests.utils.HawtioOnlineTestUtils;
+import io.hawt.v2.Hawtio;
+import io.hawt.v2.HawtioSpec;
+
+/**
+ * Tests for operator namespace watching behavior based on WATCH_NAMESPACES configuration.
+ * These tests verify that the operator correctly reconciles Hawtio CRs based on its
+ * configured watch scope (AllNamespaces, OwnNamespace, SingleNamespace).
+ *
+ * WATCH_NAMESPACES behavior:
+ * - Empty string ("") = AllNamespaces mode - watches all namespaces in the cluster
+ * - Operator's own namespace = OwnNamespace mode - watches only where operator is installed
+ * - Different single namespace = SingleNamespace mode - watches one specific namespace
+ *
+ * Note: MultiNamespace mode is deprecated and removed in OLMv1.
+ *
+ * Each test configures the operator to the required mode, runs the test, and restores original configuration.
+ */
+public class OperatorNamespaceWatchingTest extends BaseHawtioOnlineTest {
+    private static final String OPERATOR_NAMESPACE = "openshift-operators";
+    private static final String OPERATOR_DEPLOYMENT_NAME = "hawtio-operator";
+    private static final String WATCH_NAMESPACES_ENV = "WATCH_NAMESPACES";
+
+    /**
+     * Tests that when operator is in AllNamespaces/Cluster mode, it reconciles Hawtio CRs across multiple namespaces.
+     * Expected: All CRs get reconciled regardless of which namespace they're in.
+     */
+    @Test
+    public void testAllNamespacesReconciliation() {
+        final String namespace1 = "hawtio-ns-alpha-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
+        final String namespace2 = "hawtio-ns-omega-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
+        final String crName1 = "hawtio-cr-alpha";
+        final String crName2 = "hawtio-cr-omega";
+
+        HawtioOnlineTestUtils.withCleanup(() -> {
+            // Configure operator for AllNamespaces mode (empty WATCH_NAMESPACES)
+            configureOperatorWatchNamespaces("");
+
+            // Create two separate namespaces
+            OpenshiftClient.get().createNamespace(namespace1);
+            OpenshiftClient.get().createNamespace(namespace2);
+
+            // Deploy Hawtio CRs in both namespaces
+            Hawtio hawtio1 = HawtioOnlineUtils.withBaseHawtio(crName1, namespace1, h -> {
+                h.getSpec().setType(HawtioSpec.Type.NAMESPACE);
+            });
+            Hawtio hawtio2 = HawtioOnlineUtils.withBaseHawtio(crName2, namespace2, h -> {
+                h.getSpec().setType(HawtioSpec.Type.NAMESPACE);
+            });
+
+            HawtioOnlineUtils.deployHawtioCR(hawtio1);
+            HawtioOnlineUtils.deployHawtioCR(hawtio2);
+
+            SoftAssertions sa = new SoftAssertions();
+
+            Hawtio reconciledCR1 = OpenshiftClient.get().resources(Hawtio.class)
+                .inNamespace(namespace1).withName(crName1).get();
+            sa.assertThat(reconciledCR1.getStatus().getPhase().name())
+                .as("CR in namespace1 should be Deployed")
+                .isEqualTo("DEPLOYED");
+            sa.assertThat(reconciledCR1.getStatus().getURL())
+                .as("CR in namespace1 should have a URL")
+                .isNotNull()
+                .isNotEmpty();
+
+            Hawtio reconciledCR2 = OpenshiftClient.get().resources(Hawtio.class)
+                .inNamespace(namespace2).withName(crName2).get();
+            sa.assertThat(reconciledCR2.getStatus().getPhase().name())
+                .as("CR in namespace2 should be Deployed")
+                .isEqualTo("DEPLOYED");
+            sa.assertThat(reconciledCR2.getStatus().getURL())
+                .as("CR in namespace2 should have a URL")
+                .isNotNull()
+                .isNotEmpty();
+
+            sa.assertAll();
+        }, () -> {
+            OpenshiftClient.get().namespaces().withName(namespace1).delete();
+            OpenshiftClient.get().namespaces().withName(namespace2).delete();
+            restoreOperatorToAllNamespaces();
+        });
+    }
+
+    /**
+     * OwnNamespace Mode - Operator watches its own namespace only
+     *
+     * Tests that when operator watches only the namespace where it's installed (OwnNamespace mode):
+     * - Reconciles CRs in the same namespace as the operator (openshift-operators)
+     * - Ignores CRs in other namespaces
+     *
+     * Expected: Only CR in operator's namespace gets reconciled; CRs in other namespaces remain unreconciled.
+     */
+    @Test
+    public void testOwnNamespaceIsolation() {
+        final String ignoredNamespace = "hawtio-ignored-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
+        final String crNameInOperatorNs = "hawtio-cr-own-ns";
+        final String crNameIgnored = "hawtio-cr-ignored";
+
+        HawtioOnlineTestUtils.withCleanup(() -> {
+            // Configure operator for OwnNamespace mode (WATCH_NAMESPACES = operator's own namespace)
+            configureOperatorWatchNamespaces(OPERATOR_NAMESPACE);
+
+            // Create namespace that should be ignored
+            OpenshiftClient.get().createNamespace(ignoredNamespace);
+
+            // Deploy CR in operator's own namespace - should reconcile
+            Hawtio hawtioInOperatorNs = HawtioOnlineUtils.withBaseHawtio(crNameInOperatorNs, OPERATOR_NAMESPACE, h -> {
+                h.getSpec().setType(HawtioSpec.Type.NAMESPACE);
+            });
+            HawtioOnlineUtils.deployHawtioCR(hawtioInOperatorNs);
+
+            // Deploy CR in ignored namespace - should NOT reconcile
+            Hawtio hawtioIgnored = HawtioOnlineUtils.withBaseHawtio(crNameIgnored, ignoredNamespace, h -> {
+                h.getSpec().setType(HawtioSpec.Type.NAMESPACE);
+            });
+            OpenshiftClient.get().resources(Hawtio.class).inNamespace(ignoredNamespace).create(hawtioIgnored);
+
+            // Wait for the CR to be created (verify it exists in etcd)
+            WaitUtils.waitFor(() -> {
+                Hawtio cr = OpenshiftClient.get().resources(Hawtio.class)
+                    .inNamespace(ignoredNamespace).withName(crNameIgnored).get();
+                return cr != null && cr.getMetadata() != null;
+            }, "Waiting for ignored CR to be created", Duration.ofSeconds(5));
+
+            // Wait for the operator to reconcile the CR in its own namespace
+            WaitUtils.waitFor(() -> {
+                Hawtio cr = OpenshiftClient.get().resources(Hawtio.class)
+                    .inNamespace(OPERATOR_NAMESPACE).withName(crNameInOperatorNs).get();
+                return cr != null
+                    && cr.getStatus() != null
+                    && cr.getStatus().getPhase() != null
+                    && "DEPLOYED".equals(cr.getStatus().getPhase().name())
+                    && cr.getStatus().getURL() != null;
+            }, "Waiting for operator namespace CR to be reconciled", Duration.ofSeconds(20));
+
+            SoftAssertions sa = new SoftAssertions();
+
+            // Verify CR in operator's own namespace is reconciled
+            Hawtio reconciledInOperatorNs = OpenshiftClient.get().resources(Hawtio.class)
+                .inNamespace(OPERATOR_NAMESPACE).withName(crNameInOperatorNs).get();
+            sa.assertThat(reconciledInOperatorNs.getStatus().getPhase().name())
+                .as("CR in operator's own namespace should be Deployed")
+                .isEqualTo("DEPLOYED");
+            sa.assertThat(reconciledInOperatorNs.getStatus().getURL())
+                .as("CR in operator's own namespace should have a URL")
+                .isNotNull();
+
+            // Verify ignored CR exists but is NOT reconciled
+            Hawtio ignoredCR = OpenshiftClient.get().resources(Hawtio.class)
+                .inNamespace(ignoredNamespace).withName(crNameIgnored).get();
+            sa.assertThat(ignoredCR)
+                .as("CR in ignored namespace should exist")
+                .isNotNull();
+            sa.assertThat(ignoredCR.getStatus())
+                .as("CR in ignored namespace should have no status (not reconciled)")
+                .isNull();
+
+            sa.assertAll();
+        }, () -> {
+            OpenshiftClient.get().resources(Hawtio.class).inNamespace(OPERATOR_NAMESPACE).withName(crNameInOperatorNs).delete();
+            OpenshiftClient.get().namespaces().withName(ignoredNamespace).delete();
+            restoreOperatorToAllNamespaces();
+        });
+    }
+
+    /**
+     * Tests SingleNamespace mode where operator is installed in one namespace but watches a DIFFERENT namespace:
+     * - Operator installed in openshift-operators namespace
+     * - Operator watches a specific different namespace
+     * - Ignores all other namespaces including operator's own namespace
+     *
+     * Expected: Only CR in the watched namespace gets reconciled but CRs in other namespaces remain unreconciled.
+     */
+    @Test
+    public void testSingleNamespaceMode() {
+        final String watchedNamespace = "hawtio-watched-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
+        final String ignoredNamespace = "hawtio-ignored-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
+        final String crNameInOperatorNs = "hawtio-operator-ns";
+        final String crNameInWatchedNs = "hawtio-watched-ns";
+        final String crNameInIgnoredNs = "hawtio-ignored-ns";
+
+        HawtioOnlineTestUtils.withCleanup(() -> {
+            // Create the watched namespace first (needed before configuring operator)
+            OpenshiftClient.get().createNamespace(watchedNamespace);
+
+            // Configure operator for SingleNamespace mode (WATCH_NAMESPACES = specific different namespace)
+            configureOperatorWatchNamespaces(watchedNamespace);
+
+            // Create ignored namespace
+            OpenshiftClient.get().createNamespace(ignoredNamespace);
+
+            // Deploy CR in operator's own namespace (should be ignored in SingleNamespace mode)
+            Hawtio crInOperatorNs = HawtioOnlineUtils.withBaseHawtio(crNameInOperatorNs, OPERATOR_NAMESPACE, h -> {
+                h.getSpec().setType(HawtioSpec.Type.NAMESPACE);
+            });
+            OpenshiftClient.get().resources(Hawtio.class).inNamespace(OPERATOR_NAMESPACE).create(crInOperatorNs);
+
+            // Wait for CR in operator namespace to be created
+            WaitUtils.waitFor(() -> {
+                Hawtio cr = OpenshiftClient.get().resources(Hawtio.class)
+                    .inNamespace(OPERATOR_NAMESPACE).withName(crNameInOperatorNs).get();
+                return cr != null && cr.getMetadata() != null;
+            }, "Waiting for CR in operator namespace to be created", Duration.ofSeconds(5));
+
+            // Deploy CR in watched namespace (should be reconciled)
+            Hawtio crInWatchedNs = HawtioOnlineUtils.withBaseHawtio(crNameInWatchedNs, watchedNamespace, h -> {
+                h.getSpec().setType(HawtioSpec.Type.NAMESPACE);
+            });
+            HawtioOnlineUtils.deployHawtioCR(crInWatchedNs);
+
+            // Deploy CR in ignored namespace (should be ignored)
+            Hawtio crInIgnoredNs = HawtioOnlineUtils.withBaseHawtio(crNameInIgnoredNs, ignoredNamespace, h -> {
+                h.getSpec().setType(HawtioSpec.Type.NAMESPACE);
+            });
+            OpenshiftClient.get().resources(Hawtio.class).inNamespace(ignoredNamespace).create(crInIgnoredNs);
+
+            // Wait for CR in ignored namespace to be created
+            WaitUtils.waitFor(() -> {
+                Hawtio cr = OpenshiftClient.get().resources(Hawtio.class)
+                    .inNamespace(ignoredNamespace).withName(crNameInIgnoredNs).get();
+                return cr != null && cr.getMetadata() != null;
+            }, "Waiting for CR in ignored namespace to be created", Duration.ofSeconds(5));
+
+            // Wait for the operator to reconcile the CR in the watched namespace
+            WaitUtils.waitFor(() -> {
+                Hawtio cr = OpenshiftClient.get().resources(Hawtio.class)
+                    .inNamespace(watchedNamespace).withName(crNameInWatchedNs).get();
+                return cr != null
+                    && cr.getStatus() != null
+                    && cr.getStatus().getPhase() != null
+                    && "DEPLOYED".equals(cr.getStatus().getPhase().name())
+                    && cr.getStatus().getURL() != null;
+            }, "Waiting for watched namespace CR to be reconciled", Duration.ofSeconds(20));
+
+            SoftAssertions sa = new SoftAssertions();
+
+            // Verify watched namespace CR is reconciled
+            Hawtio reconciledWatched = OpenshiftClient.get().resources(Hawtio.class)
+                .inNamespace(watchedNamespace).withName(crNameInWatchedNs).get();
+            sa.assertThat(reconciledWatched.getStatus().getPhase().name())
+                .as("CR in watched namespace should be Deployed")
+                .isEqualTo("DEPLOYED");
+            sa.assertThat(reconciledWatched.getStatus().getURL())
+                .as("CR in watched namespace should have a URL")
+                .isNotNull();
+
+            // Verify CR in operator's own namespace exists but is NOT reconciled (SingleNamespace != OwnNamespace)
+            Hawtio crOperatorNs = OpenshiftClient.get().resources(Hawtio.class)
+                .inNamespace(OPERATOR_NAMESPACE).withName(crNameInOperatorNs).get();
+            sa.assertThat(crOperatorNs)
+                .as("CR in operator's own namespace should exist")
+                .isNotNull();
+            sa.assertThat(crOperatorNs.getStatus())
+                .as("CR in operator's own namespace should NOT be reconciled in SingleNamespace mode")
+                .isNull();
+
+            // Verify CR in ignored namespace exists but is NOT reconciled
+            Hawtio crIgnoredNs = OpenshiftClient.get().resources(Hawtio.class)
+                .inNamespace(ignoredNamespace).withName(crNameInIgnoredNs).get();
+            sa.assertThat(crIgnoredNs)
+                .as("CR in ignored namespace should exist")
+                .isNotNull();
+            sa.assertThat(crIgnoredNs.getStatus())
+                .as("CR in ignored namespace should NOT be reconciled")
+                .isNull();
+
+            sa.assertAll();
+        }, () -> {
+            OpenshiftClient.get().resources(Hawtio.class).inNamespace(OPERATOR_NAMESPACE).withName(crNameInOperatorNs).delete();
+            OpenshiftClient.get().namespaces().withName(ignoredNamespace).delete();
+            OpenshiftClient.get().namespaces().withName(watchedNamespace).delete();
+            restoreOperatorToAllNamespaces();
+        });
+    }
+
+    /**
+     * Configures operator to watch specific namespaces via Subscription.
+     * OLM will propagate changes to Deployment and restart the pod.
+     * @param watchNamespaces Namespace to watch, or null/empty string for AllNamespaces mode (use default)
+     */
+    private void configureOperatorWatchNamespaces(String watchNamespaces) {
+        updateSubscriptionEnv(WATCH_NAMESPACES_ENV, watchNamespaces);
+        waitForOperatorRollout();
+    }
+
+    /**
+     * Updates an environment variable in the operator Subscription.
+     * @param name Environment variable name
+     * @param value Environment variable value, or null/empty to remove the override
+     */
+    private void updateSubscriptionEnv(String name, String value) {
+        OpenshiftClient.get().resources(Subscription.class)
+            .inNamespace(OPERATOR_NAMESPACE)
+            .withName("red-hat-hawtio-operator")
+            .edit(sub -> {
+                var spec = sub.getSpec();
+                var config = Optional.ofNullable(spec.getConfig()).orElseGet(SubscriptionConfig::new);
+                var envs = Optional.ofNullable(config.getEnv()).orElseGet(ArrayList::new);
+
+                // Clean & Replace
+                envs.removeIf(e -> e.getName().equals(name));
+                if (value != null && !value.isEmpty()) {
+                    envs.add(new EnvVarBuilder().withName(name).withValue(value).build());
+                }
+
+                config.setEnv(envs);
+                spec.setConfig(config);
+                return sub;
+            });
+    }
+
+    /**
+     * Waits for the operator Deployment to complete rollout after configuration changes.
+     */
+    private void waitForOperatorRollout() {
+        // First, wait for any old pods to fully terminate
+        WaitUtils.waitFor(() -> {
+            var pods = OpenshiftClient.get().pods()
+                .inNamespace(OPERATOR_NAMESPACE)
+                .withLabel("name", OPERATOR_DEPLOYMENT_NAME)
+                .list()
+                .getItems();
+
+            // No pods should be in terminating state
+            return pods.stream().noneMatch(pod -> pod.getMetadata().getDeletionTimestamp() != null);
+        }, "Waiting for old operator pods to terminate", Duration.ofSeconds(60));
+
+        // Then wait for deployment to be ready
+        OpenshiftClient.get().apps().deployments()
+            .inNamespace(OPERATOR_NAMESPACE)
+            .withName(OPERATOR_DEPLOYMENT_NAME)
+            .waitUntilReady(3, TimeUnit.MINUTES);
+
+        // Finally, ensure exactly one pod is running and ready
+        WaitUtils.waitFor(() -> {
+            var pods = OpenshiftClient.get().pods()
+                .inNamespace(OPERATOR_NAMESPACE)
+                .withLabel("name", OPERATOR_DEPLOYMENT_NAME)
+                .list()
+                .getItems();
+
+            if (pods.size() != 1) {
+                return false;
+            }
+
+            var pod = pods.get(0);
+            var phase = pod.getStatus().getPhase();
+
+            // Fail fast only on terminal failure states
+            // Do not fail on transient states like "Pending" or "ContainerCreating"
+            if ("Failed".equals(phase)) {
+                throw new AssertionError("Operator pod failed - check pod logs for details");
+            }
+            if ("Unknown".equals(phase)) {
+                throw new AssertionError("Operator pod in unknown state - possible node/kubelet issue");
+            }
+
+            // For non-running states (Pending, ContainerCreating), keep waiting
+            if (!"Running".equals(phase)) {
+                return false;
+            }
+
+            // Pod is terminating
+            if (pod.getMetadata().getDeletionTimestamp() != null) {
+                return false;
+            }
+
+            // Check all containers are ready
+            return pod.getStatus().getContainerStatuses() != null
+                && pod.getStatus().getContainerStatuses().stream()
+                    .allMatch(cs -> Boolean.TRUE.equals(cs.getReady()));
+        }, "Waiting for operator to settle into new watch mode", Duration.ofSeconds(30));
+    }
+
+    /**
+     * Restores operator to AllNamespaces mode (OLMv1 default).
+     */
+    private void restoreOperatorToAllNamespaces() {
+        configureOperatorWatchNamespaces("");
+    }
+}

--- a/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/openshift/acl.yaml
+++ b/tests/hawtio-test-suite/src/test/resources/io/hawt/tests/openshift/acl.yaml
@@ -179,7 +179,7 @@ org.apache.camel.context:
   getLoad15: admin, viewer
   getCamelVersion: admin, viewer
   getApplicationContextClassName: admin, viewer
-#  getTotalRoutes: admin, viewer
+  #  getTotalRoutes: admin, viewer
   getStartedRoutes: admin, viewer
   isMessageHistory: admin, viewer
   getTimeUnit: admin, viewer


### PR DESCRIPTION
In this PR:
- Added new Hawtio Online tests which cover AllNamespaces, OwnNamespace, SingleNamespace installation modes;
- Stabilized a few flakiness in the Operator tests;
- Enabled the RBAC test
- - Fixed ACL yaml file as it wasn't correct in the test suite
- - Some UI elements were changed, so it required a small refactoring and fixes in the assertions/checks
- Removed a custom logo test as previously an external source was used and now it's blocked by Content Source Policy, therefore, we will need to refactor the test later and for now we temporarily disabled it to avoid test run failures;

Checked it in our environment and all tests pass - `Tests run: 140, Failures: 0, Errors: 0, Skipped: 6`