### PR TITLE
[E2E] Extend RBAC tests.

### DIFF
--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/online/DiscoverTab.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/pageobjects/fragments/online/DiscoverTab.java
@@ -77,7 +77,7 @@ public class DiscoverTab {
     public void selectNamespace(String namespace) {
         waitForPageLoaded();
         final SelenideElement namespaceTab = $(DISCOVER_TABS).$(ByUtils.byPartialText(namespace));
-        namespaceTab.should(exist, Duration.ofSeconds(60)); // Increased timeout for cluster discovery
+        namespaceTab.should(exist, Duration.ofSeconds(120)); // Increased timeout for cluster discovery
         if (namespaceTab.is(Condition.interactable)) {
             namespaceTab.click();
         }
@@ -118,5 +118,6 @@ public class DiscoverTab {
     private void waitForPageLoaded() {
         $(ByUtils.byDataTestId("loading")).shouldNot(exist, Duration.ofSeconds(30));
         $(ACTIVE_DEPLOYMENT_LIST).should(exist, Duration.ofSeconds(30));
+        $(DISCOVER_TABS).should(exist, Duration.ofSeconds(30));
     }
 }

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/HawtioOperatorTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/HawtioOperatorTest.java
@@ -335,7 +335,7 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
     }
 
     @Test
-    public void testRBAC() throws IOException {
+    public void testCustomRBAC() throws IOException {
         final String configMapName = "rbac-test-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
         final String namespace = TestConfiguration.getOpenshiftNamespace();
 
@@ -404,6 +404,42 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
                 .withName(configMapName)
                 .delete();
         }
+    }
+
+    @Test
+    public void testDefaultRBAC() throws IOException {
+        runTest(spec -> {
+            var rbac = new Rbac();
+            spec.setRbac(rbac);
+        }, sa -> {
+            var discoverTab = new DiscoverTab();
+            discoverTab.assertContainsDeployment(deployment.getMetadata().getName());
+            discoverTab.connectTo(podName);
+
+            WaitUtils.waitForPageLoad();
+            var hawtio = new HawtioPage();
+
+            hawtio.menu().navigateTo("Camel");
+            final CamelPage camelPage = new CamelPage();
+
+            camelPage.tree().selectSpecificItem("CamelContexts-SampleCamel-folder");
+            camelPage.openTab("Operations");
+
+            final CamelOperations camelOperations = new CamelOperations();
+            camelOperations.checkOperation("stop()", Condition.enabled);
+            camelOperations.checkOperation("getTotalRoutes()", Condition.enabled);
+
+            hawtio.panel().logout();
+            new HawtioOnlineLoginPage().login("viewer", "viewer");
+
+            LoginLogout.hawtioIsLoaded();
+            camelPage.tree().selectSpecificItem("CamelContexts-SampleCamel-folder");
+            camelPage.openTab("Operations");
+
+            camelOperations.checkOperation("stop()", Condition.disabled);
+            camelOperations.checkOperation("restart()", Condition.disabled);
+            camelOperations.checkOperation("getTotalRoutes()", Condition.enabled);
+        });
     }
 
     @Test


### PR DESCRIPTION
- Added a new RBAC test - now the tests check the custom and default RBAC
- Increased timeout for cluster discovery test (it doesn't wait the whole 120 seconds, just the max time to wait)
- Added a new assertion for the page load

Tested on OCP 4.18 and 4.21, all passed