### PR TITLE
[E2E] Update the checkout workflow files.

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,7 +1,7 @@
 name: E2E Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - 4.x
@@ -39,13 +39,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-        if: github.event_name == 'pull_request_target'
-        with:
-          ref: "refs/pull/${{ github.event.number }}/merge"
-          persist-credentials: false
-      - name: Checkout code
-        uses: actions/checkout@v6
-        if: github.event_name == 'push'
         with:
           persist-credentials: false
       - name: Set up Java
@@ -117,57 +110,59 @@ jobs:
             ${{ env.REPORT_DIR }}/*.log
             ${{ env.REPORT_DIR }}/cucumber-reports/*
 
-  publish-results:
-    runs-on: ubuntu-latest
-    needs: test
-    if: always()
-    permissions:
-      checks: write
-      actions: read
-      pull-requests: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Archive failed test reports
-        uses: actions/upload-artifact/merge@v4
-        if: always()
-        with:
-          name: "test-results"
-          pattern: test-results-*
-          separate-directories: true
-      - name: Download Test Results
-        uses: actions/download-artifact@v4
-        with:
-          name: "test-results"
-          path: "test-results"
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
-        with:
-          files: |
-            **/Cucumber.xml
-          json_file: results.json
-      - name: Install xmllint
-        run: sudo apt-get install -y xmlstarlet jq
-      - name: Generate summary
-        run: |
-          export CHECK_URL=$(jq -r .check_url results.json)
-          bash tests/hawtio-test-suite/process_test_results.sh test-results > summary.md
-      - name: Update summary
-        run: |
-          cat summary.md >> $GITHUB_STEP_SUMMARY
-      - uses: tibdex/github-app-token@v2
-        if: github.event_name == 'pull_request_target'
-        id: generate-token
-        with:
-          app_id: ${{ secrets.HAWTIO_CI_APP_ID }}
-          private_key: ${{ secrets.HAWTIO_CI_PRIVATE_KEY }}
-      - name: Comment PR with summary
-        if: github.event_name == 'pull_request_target'
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          filePath: summary.md
-          comment_tag: execution
+  # TEMPORARILY DISABLED - requires pull_request_target for secrets/permissions
+  # Will be moved to separate workflow_run workflow for security
+  # publish-results:
+  #   runs-on: ubuntu-latest
+  #   needs: test
+  #   if: always()
+  #   permissions:
+  #     checks: write
+  #     actions: read
+  #     pull-requests: write
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v6
+  #       with:
+  #         persist-credentials: false
+  #     - name: Archive failed test reports
+  #       uses: actions/upload-artifact/merge@v4
+  #       if: always()
+  #       with:
+  #         name: "test-results"
+  #         pattern: test-results-*
+  #         separate-directories: true
+  #     - name: Download Test Results
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: "test-results"
+  #         path: "test-results"
+  #     - name: Publish Test Results
+  #       uses: EnricoMi/publish-unit-test-result-action@v2
+  #       if: always()
+  #       with:
+  #         files: |
+  #           **/Cucumber.xml
+  #         json_file: results.json
+  #     - name: Install xmllint
+  #       run: sudo apt-get install -y xmlstarlet jq
+  #     - name: Generate summary
+  #       run: |
+  #         export CHECK_URL=$(jq -r .check_url results.json)
+  #         bash tests/hawtio-test-suite/process_test_results.sh test-results > summary.md
+  #     - name: Update summary
+  #       run: |
+  #         cat summary.md >> $GITHUB_STEP_SUMMARY
+  #     - uses: tibdex/github-app-token@v2
+  #       if: github.event_name == 'pull_request_target'
+  #       id: generate-token
+  #       with:
+  #         app_id: ${{ secrets.HAWTIO_CI_APP_ID }}
+  #         private_key: ${{ secrets.HAWTIO_CI_PRIVATE_KEY }}
+  #     - name: Comment PR with summary
+  #       if: github.event_name == 'pull_request_target'
+  #       uses: thollander/actions-comment-pull-request@v2
+  #       with:
+  #         GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+  #         filePath: summary.md
+  #         comment_tag: execution

--- a/.github/workflows/jbang-test.yml
+++ b/.github/workflows/jbang-test.yml
@@ -1,7 +1,7 @@
 name: JBang Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - 4.x
@@ -30,13 +30,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-        if: github.event_name == 'pull_request_target'
-        with:
-          ref: "refs/pull/${{ github.event.number }}/merge"
-          persist-credentials: false
-      - name: Checkout code
-        uses: actions/checkout@v6
-        if: github.event_name == 'push'
         with:
           persist-credentials: false
       - name: Set up Java


### PR DESCRIPTION
In this PR:
- A security advisory suggests to use pull_request
- As GitHub strips out all secrets and all tokens are strictly read-only, the steps using the tokens will fail immediately
  - As a temporal solution is to disable them, so no summary comments in the PR for a while
  - And then refactor the workflow files to use a two-workflow approach which is a common practice nowadays
- The updated workflow files have been tested here (passed):
  - e2e: https://github.com/jsolovjo/hawtio/actions/runs/28160696287
  - jbang: https://github.com/jsolovjo/hawtio/actions/runs/28160696203