### PR TITLE
[E2E] Remove workflow steps which used tokens.

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -110,59 +110,43 @@ jobs:
             ${{ env.REPORT_DIR }}/*.log
             ${{ env.REPORT_DIR }}/cucumber-reports/*
 
-  # TEMPORARILY DISABLED - requires pull_request_target for secrets/permissions
-  # Will be moved to separate workflow_run workflow for security
-  # publish-results:
-  #   runs-on: ubuntu-latest
-  #   needs: test
-  #   if: always()
-  #   permissions:
-  #     checks: write
-  #     actions: read
-  #     pull-requests: write
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v6
-  #       with:
-  #         persist-credentials: false
-  #     - name: Archive failed test reports
-  #       uses: actions/upload-artifact/merge@v4
-  #       if: always()
-  #       with:
-  #         name: "test-results"
-  #         pattern: test-results-*
-  #         separate-directories: true
-  #     - name: Download Test Results
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: "test-results"
-  #         path: "test-results"
-  #     - name: Publish Test Results
-  #       uses: EnricoMi/publish-unit-test-result-action@v2
-  #       if: always()
-  #       with:
-  #         files: |
-  #           **/Cucumber.xml
-  #         json_file: results.json
-  #     - name: Install xmllint
-  #       run: sudo apt-get install -y xmlstarlet jq
-  #     - name: Generate summary
-  #       run: |
-  #         export CHECK_URL=$(jq -r .check_url results.json)
-  #         bash tests/hawtio-test-suite/process_test_results.sh test-results > summary.md
-  #     - name: Update summary
-  #       run: |
-  #         cat summary.md >> $GITHUB_STEP_SUMMARY
-  #     - uses: tibdex/github-app-token@v2
-  #       if: github.event_name == 'pull_request_target'
-  #       id: generate-token
-  #       with:
-  #         app_id: ${{ secrets.HAWTIO_CI_APP_ID }}
-  #         private_key: ${{ secrets.HAWTIO_CI_PRIVATE_KEY }}
-  #     - name: Comment PR with summary
-  #       if: github.event_name == 'pull_request_target'
-  #       uses: thollander/actions-comment-pull-request@v2
-  #       with:
-  #         GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-  #         filePath: summary.md
-  #         comment_tag: execution
+  publish-results:
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    permissions:
+      checks: write
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Archive failed test reports
+        uses: actions/upload-artifact/merge@v4
+        if: always()
+        with:
+          name: "test-results"
+          pattern: test-results-*
+          separate-directories: true
+      - name: Download Test Results
+        uses: actions/download-artifact@v4
+        with:
+          name: "test-results"
+          path: "test-results"
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: |
+            **/Cucumber.xml
+          json_file: results.json
+      - name: Install xmllint
+        run: sudo apt-get install -y xmlstarlet jq
+      - name: Generate summary
+        run: |
+          export CHECK_URL=$(jq -r .check_url results.json)
+          bash tests/hawtio-test-suite/process_test_results.sh test-results > summary.md
+      - name: Update summary
+        run: |
+          cat summary.md >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
In this PR:
- Removed pull-requests: write permission from publish-results job
- Removed GitHub App token generation step
- Removed automated PR comment step
- Re-enabled publish-results job (was previously commented out)

Why we kept publish-results - the publish-results job still provides valuable feedback:
- Test result checks - Creates GitHub check runs visible on PRs showing pass/fail status and detailed results
- Workflow summaries - Adds formatted test summaries to the Actions tab
- Artifact aggregation - Merges test artifacts from matrix runs into a single archive

Tested in my private fork:
- JBang tests - https://github.com/jsolovjo/hawtio/actions/runs/28224078422
- E2E tests - https://github.com/jsolovjo/hawtio/actions/runs/28224078420