### PR TITLE
[E2E] resolves: #4373 Upgrade E2E to springboot4 runtime module

### DIFF
--- a/tests/springboot/pom.xml
+++ b/tests/springboot/pom.xml
@@ -11,7 +11,7 @@
 
   <artifactId>hawtio-tests-springboot</artifactId>
   <name>${project.artifactId}</name>
-  <description>Hawtio :: Spring Boot 3.x E2E tests</description>
+  <description>Hawtio :: Spring Boot 4.x E2E tests</description>
   <packaging>jar</packaging>
 
   <properties>
@@ -33,14 +33,14 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-framework-bom</artifactId>
-        <version>${spring-version}</version>
+        <version>${spring7-version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring-boot-version}</version>
+        <version>${spring-boot4-version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -66,22 +66,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-tomcat</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-undertow</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>io.undertow</groupId>
-          <artifactId>undertow-websockets-jsr</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -120,7 +104,7 @@
     <!-- hawtio -->
     <dependency>
       <groupId>io.hawt</groupId>
-      <artifactId>hawtio-springboot</artifactId>
+      <artifactId>hawtio-springboot4</artifactId>
     </dependency>
 
     <!--
@@ -130,6 +114,14 @@
     <dependency>
       <groupId>io.hawt</groupId>
       <artifactId>hawtio-log-logback</artifactId>
+    </dependency>
+
+    <!-- Spring Boot 4 requires Jakarta EE 11 and Servlet API 6.1 -->
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${servlet-api61-version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Camel -->
@@ -204,7 +196,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${spring-boot-version}</version>
+        <version>${spring-boot4-version}</version>
         <configuration>
           <mainClass>io.hawt.tests.spring.boot.SpringBootService</mainClass>
           <jvmArguments>

--- a/tests/springboot/src/main/java/io/hawt/tests/spring/boot/SpringBootService.java
+++ b/tests/springboot/src/main/java/io/hawt/tests/spring/boot/SpringBootService.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 import jakarta.annotation.PostConstruct;
 
-import io.hawt.springboot.HawtioPlugin;
+import io.hawt.springboot4.HawtioPlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;

--- a/tests/springboot/src/main/resources/hawtio-static/hawtconfig.json
+++ b/tests/springboot/src/main/resources/hawtio-static/hawtconfig.json
@@ -1,6 +1,6 @@
 {
   "branding": {
-    "appName": "Hawtio Spring Boot 3 Sample app for E2E testing purposes",
+    "appName": "Hawtio Spring Boot 4 Sample app for E2E testing purposes",
     "appLogoUrl": "img/hawtio-logo.svg",
     "appLogoDarkModeUrl": "img/hawtio-logo-darkmode.svg",
     "css": "css/app.css",


### PR DESCRIPTION
Change:
- Spring Boot framework BOM version 
- Updated dependencies and imports 
- Added Jakarta Servlet API
- Had to remove _undertow_, since it got dropped with [spring boot 4](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide) 