### PR TITLE
[E2E] Disable comment step in publish results job.

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -141,6 +141,7 @@ jobs:
           files: |
             **/Cucumber.xml
           json_file: results.json
+          comment_mode: off
       - name: Install xmllint
         run: sudo apt-get install -y xmlstarlet jq
       - name: Generate summary


### PR DESCRIPTION
This will:
- Prevent the 403 error on branch-based PRs
- Make behavior consistent for both fork and branch PRs
- Eliminate the need for pull-requests: write permission (more secure)
- Still provide test results via check runs, annotations, and job summaries