### PR TITLE
Replace deprecated methods in random+logback

### DIFF
--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/config/TestConfiguration.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/config/TestConfiguration.java
@@ -237,7 +237,7 @@ public class TestConfiguration {
 
     public static String getOpenshiftNamespace() {
         if (getOptionalProperty(OPENSHIFT_NAMESPACE).isEmpty()) {
-            System.setProperty(OPENSHIFT_NAMESPACE, NAMESPACE_PREFIX + RandomStringUtils.randomAlphabetic(5).toLowerCase());
+            System.setProperty(OPENSHIFT_NAMESPACE, NAMESPACE_PREFIX + RandomStringUtils.secure().nextAlphabetic(5).toLowerCase());
         }
 
         return getRequiredProperty(OPENSHIFT_NAMESPACE);

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/HawtioOnlineUtils.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/HawtioOnlineUtils.java
@@ -101,7 +101,7 @@ public class HawtioOnlineUtils {
                         .addToAnnotations(annotations)
                         .addToLabels("app", name)
                         //Used to differentiate the pod hash of the Replica Sets
-                        .addToLabels("randomId", RandomStringUtils.randomAlphabetic(5))
+                        .addToLabels("randomId", RandomStringUtils.secure().nextAlphabetic(5))
                     .endMetadata()
                     .editOrNewSpec()
                         .addNewContainer()

--- a/tests/hawtio-test-suite/src/main/resources/logback-test.xml
+++ b/tests/hawtio-test-suite/src/main/resources/logback-test.xml
@@ -23,7 +23,7 @@
   </appender>
   <root level="INFO">
     <appender-ref ref="CUCUMBER-LOG"/>
-    <appender-ref ref="STDOUT-WARNING"/>
+    <appender-ref ref="STDOUT-WARNINGS"/>
   </root>
   <logger name="io.hawt">
     <appender-ref ref="STDOUT" />

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/ClusterDiscoveryTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/ClusterDiscoveryTest.java
@@ -46,7 +46,7 @@ public class ClusterDiscoveryTest extends BaseHawtioOnlineTest {
 
     @Test
     public void testClusterModeDiscoversCrossNamespaceApps() {
-        final String namespace = "e2e-discover-namespace-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
+        final String namespace = "e2e-discover-namespace-" + RandomStringUtils.secure().nextAlphabetic(5).toLowerCase();
 
         HawtioOnlineTestUtils.withCleanup(() -> {
             OpenshiftClient.get().createNamespace(namespace);

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/HawtioOperatorTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/HawtioOperatorTest.java
@@ -79,7 +79,7 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
 
     @BeforeAll
     public static void setupApp() {
-        String name = "camel-app-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
+        String name = "camel-app-" + RandomStringUtils.secure().nextAlphabetic(5).toLowerCase();
         deployment = HawtioOnlineUtils.deployApplication(name, "springboot", TestConfiguration.getOpenshiftNamespace(), "5.x-" + (System.getProperty("java.vm.specification.version", "21")));
         podName = OpenshiftClient.get().pods().withLabel("app", name).list().getItems().get(0).getMetadata().getName();
     }
@@ -198,7 +198,7 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
 
     @Test
     public void testProjectSelector() {
-        final String namespace = "selector-tests-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
+        final String namespace = "selector-tests-" + RandomStringUtils.secure().nextAlphabetic(5).toLowerCase();
 
         OpenshiftClient.get()
             .resource(new NamespaceBuilder().withNewMetadata().withName(namespace).addToLabels("myLabel", namespace).endMetadata().build()).create();
@@ -258,7 +258,7 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
         HawtioOnlineTestUtils.withCleanup(() -> {
 
             hawtio =
-                HawtioOnlineUtils.withBaseHawtio("operator-test-" + RandomStringUtils.randomAlphabetic(5).toLowerCase(),
+                HawtioOnlineUtils.withBaseHawtio("operator-test-" + RandomStringUtils.secure().nextAlphabetic(5).toLowerCase(),
                     TestConfiguration.getOpenshiftNamespace(),
                     h -> {
                         h.getSpec().setType(HawtioSpec.Type.NAMESPACE);
@@ -336,7 +336,7 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
 
     @Test
     public void testCustomRBAC() throws IOException {
-        final String configMapName = "rbac-test-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
+        final String configMapName = "rbac-test-" + RandomStringUtils.secure().nextAlphabetic(5).toLowerCase();
         final String namespace = TestConfiguration.getOpenshiftNamespace();
 
         try {
@@ -663,7 +663,7 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
     public void testCRUpdatePreservesAllFields() {
         // Regression test for operator cache issue where updates would remove fields
         HawtioOnlineTestUtils.withCleanup(() -> {
-            hawtio = HawtioOnlineUtils.withBaseHawtio("operator-test-" + RandomStringUtils.randomAlphabetic(5).toLowerCase(),
+            hawtio = HawtioOnlineUtils.withBaseHawtio("operator-test-" + RandomStringUtils.secure().nextAlphabetic(5).toLowerCase(),
                 TestConfiguration.getOpenshiftNamespace(),
                 h -> {
                     h.getSpec().setType(HawtioSpec.Type.NAMESPACE);
@@ -741,7 +741,7 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
 
     private static void runTest(Consumer<HawtioSpec> consumer, Consumer<SoftAssertions> testFunction, boolean startBrowser) {
         hawtio =
-            HawtioOnlineUtils.withBaseHawtio("operator-test-" + RandomStringUtils.randomAlphabetic(5).toLowerCase(),
+            HawtioOnlineUtils.withBaseHawtio("operator-test-" + RandomStringUtils.secure().nextAlphabetic(5).toLowerCase(),
                 TestConfiguration.getOpenshiftNamespace(),
                 h -> {
                     h.getSpec().setType(HawtioSpec.Type.NAMESPACE);

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/NamespacedDiscoveryTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/NamespacedDiscoveryTest.java
@@ -60,7 +60,7 @@ public class NamespacedDiscoveryTest extends BaseHawtioOnlineTest {
 
     @Test
     public void testNamespacedModeIgnoresOtherNamespaceApps() {
-        final String namespace = "hawtio-discover-test-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
+        final String namespace = "hawtio-discover-test-" + RandomStringUtils.secure().nextAlphabetic(5).toLowerCase();
         final String deploymentName = "hawtio-discover-test";
         HawtioOnlineTestUtils.withCleanup(() -> {
             OpenshiftClient.get().createNamespace(namespace);

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/OperatorNamespaceWatchingTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/OperatorNamespaceWatchingTest.java
@@ -46,8 +46,8 @@ public class OperatorNamespaceWatchingTest extends BaseHawtioOnlineTest {
      */
     @Test
     public void testAllNamespacesReconciliation() {
-        final String namespace1 = "hawtio-ns-alpha-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
-        final String namespace2 = "hawtio-ns-omega-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
+        final String namespace1 = "hawtio-ns-alpha-" + RandomStringUtils.secure().nextAlphabetic(5).toLowerCase();
+        final String namespace2 = "hawtio-ns-omega-" + RandomStringUtils.secure().nextAlphabetic(5).toLowerCase();
         final String crName1 = "hawtio-cr-alpha";
         final String crName2 = "hawtio-cr-omega";
 
@@ -111,7 +111,7 @@ public class OperatorNamespaceWatchingTest extends BaseHawtioOnlineTest {
      */
     @Test
     public void testOwnNamespaceIsolation() {
-        final String ignoredNamespace = "hawtio-ignored-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
+        final String ignoredNamespace = "hawtio-ignored-" + RandomStringUtils.secure().nextAlphabetic(5).toLowerCase();
         final String crNameInOperatorNs = "hawtio-cr-own-ns";
         final String crNameIgnored = "hawtio-cr-ignored";
 
@@ -195,8 +195,8 @@ public class OperatorNamespaceWatchingTest extends BaseHawtioOnlineTest {
      */
     @Test
     public void testSingleNamespaceMode() {
-        final String watchedNamespace = "hawtio-watched-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
-        final String ignoredNamespace = "hawtio-ignored-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
+        final String watchedNamespace = "hawtio-watched-" + RandomStringUtils.secure().nextAlphabetic(5).toLowerCase();
+        final String ignoredNamespace = "hawtio-ignored-" + RandomStringUtils.secure().nextAlphabetic(5).toLowerCase();
         final String crNameInOperatorNs = "hawtio-operator-ns";
         final String crNameInWatchedNs = "hawtio-watched-ns";
         final String crNameInIgnoredNs = "hawtio-ignored-ns";


### PR DESCRIPTION
This PR addresses a couple of warnings reported during the test build to keep the test suite clean and aligned with current dependencies.

Changes included:

https://redhat.atlassian.net/browse/HAWNG-2171 Fix Logback appender reference-
-Corrects the appender name mismatch in logback-test.xml (STDOUT-WARNING → STDOUT-WARNINGS).
-Removes Logback startup warnings and ensures the intended logging configuration is applied.

https://redhat.atlassian.net/browse/HAWNG-2168  Replace deprecated RandomStringUtils API-
-Replaces deprecated RandomStringUtils.randomAlphabetic(5) calls with RandomStringUtils.secure().nextAlphabetic(5).
-Preserves existing behavior by keeping .toLowerCase() where applicable.
-Reduces deprecation warnings from the build while maintaining the same functionality.