### PR TITLE
Replace deprecated SubjectDN+systemproperty

### DIFF
--- a/tests/hawtio-test-suite/pom.xml
+++ b/tests/hawtio-test-suite/pom.xml
@@ -303,10 +303,10 @@
         <configuration>
           <skipTests>${skipTests}</skipTests>
           <rerunFailingTestsCount>3</rerunFailingTestsCount>
-          <systemProperties>
+          <systemPropertyVariables>
             <io.hawt.test.runtime>${test-runtime}</io.hawt.test.runtime>
             <io.hawt.test.url.suffix>${hawtio.url.suffix}</io.hawt.test.url.suffix>
-          </systemProperties>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/HawtioOperatorTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/HawtioOperatorTest.java
@@ -510,7 +510,7 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
                 final CertificateFactory cf = CertificateFactory.getInstance("X.509");
                 final X509Certificate certificate =
                     (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8)));
-                assertThat(certificate.getSubjectDN().getName()).isEqualTo("CN=my.hawtio.svc");
+                assertThat(certificate.getSubjectX500Principal().getName()).isEqualTo("CN=my.hawtio.svc");
             }).doesNotThrowAnyException();
         }, false);
     }
@@ -566,7 +566,7 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
                 final CertificateFactory cf = CertificateFactory.getInstance("X.509");
                 final X509Certificate certificate =
                     (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8)));
-                assertThat(certificate.getSubjectDN().getName()).isEqualTo("CN=overflow-test.test.svc");
+                assertThat(certificate.getSubjectX500Principal().getName()).isEqualTo("CN=overflow-test.test.svc");
             }).doesNotThrowAnyException();
         }, false);
     }
@@ -614,7 +614,7 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
                 final CertificateFactory cf = CertificateFactory.getInstance("X.509");
                 final X509Certificate certificate =
                     (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8)));
-                assertThat(certificate.getSubjectDN().getName()).isEqualTo("CN=recreate-test.test.svc");
+                assertThat(certificate.getSubjectX500Principal().getName()).isEqualTo("CN=recreate-test.test.svc");
             }).doesNotThrowAnyException();
         }, false);
     }
@@ -654,7 +654,7 @@ public class HawtioOperatorTest extends BaseHawtioOnlineTest {
                 final CertificateFactory cf = CertificateFactory.getInstance("X.509");
                 final X509Certificate certificate =
                     (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8)));
-                assertThat(certificate.getSubjectDN().getName()).isEqualTo("CN=schedule-test.test.svc");
+                assertThat(certificate.getSubjectX500Principal().getName()).isEqualTo("CN=schedule-test.test.svc");
             }).doesNotThrowAnyException();
         }, false);
     }


### PR DESCRIPTION

This PR replaces deprecated APIs and Maven configuration to keep the build aligned with current standards.

1) https://redhat.atlassian.net/browse/HAWNG-2169  - Replaces 'certificate.getSubjectDN().getName()' with 'certificate.getSubjectX500Principal().getName()' to use the modern JDK certificate API and remove related deprecation warnings.
2) https://redhat.atlassian.net/browse/HAWNG-2170 - Replaces the deprecated Maven Surefire 'systemProperties' configuration with 'systemPropertyVariables' to remove build warnings and follow current Surefire conventions.