### PR TITLE
Replace deprecated Fabric8+ Jetty propertyuserstore

### DIFF
--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/HawtioOnlineUtils.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/HawtioOnlineUtils.java
@@ -115,7 +115,7 @@ public class HawtioOnlineUtils {
                 .endTemplate()
             .endSpec();
 
-        final Deployment deployment = OpenshiftClient.get().apps().deployments().createOrReplace(deploymentBuilder.build());
+        final Deployment deployment = OpenshiftClient.get().apps().deployments().resource(deploymentBuilder.build()).createOr(op -> op.update());
         //@formatter:on
 
         WaitUtils.waitFor(() -> {
@@ -234,20 +234,20 @@ public class HawtioOnlineUtils {
         // Creating duplicate OperatorGroups prevents InstallPlan creation
         if (operatorhub.operatorGroups().inNamespace(operatorNamespace).list().getItems().isEmpty()) {
             LOG.info("Creating OperatorGroup in {}", operatorNamespace);
-            operatorhub.operatorGroups().inNamespace(operatorNamespace).createOrReplace(new OperatorGroupBuilder()
+            operatorhub.operatorGroups().inNamespace(operatorNamespace).resource(new OperatorGroupBuilder()
                 .editOrNewMetadata()
                 .withName("hawtio-operator-og")
                 .withNamespace(operatorNamespace)
                 .endMetadata()
                 .editOrNewSpec()
                 .endSpec()
-                .build());
+                .build()).createOr(op -> op.update());
         } else {
             LOG.info("OperatorGroup already exists in {}, skipping creation", operatorNamespace);
         }
 
         final String subscriptionName = packageManifest.getMetadata().getName();
-        operatorhub.subscriptions().inNamespace(operatorNamespace).createOrReplace(new SubscriptionBuilder()
+        operatorhub.subscriptions().inNamespace(operatorNamespace).resource(new SubscriptionBuilder()
             .editOrNewMetadata()
             .withName(subscriptionName)
             .withNamespace(operatorNamespace)
@@ -260,7 +260,7 @@ public class HawtioOnlineUtils {
             .withSourceNamespace(catalog.getMetadata().getNamespace())
             .withStartingCSV(startingCSV)
             .endSpec()
-            .build());
+            .build()).createOr(op -> op.update());
 
         //@formatter:on
         WaitUtils.waitFor(() -> {
@@ -306,7 +306,7 @@ public class HawtioOnlineUtils {
         CatalogSource catalog = null;
         if (TestConfiguration.getIndexImage() != null) {
             //@formatter:off
-            operatorhub.catalogSources().inNamespace(operatorNamespace).createOrReplace(new CatalogSourceBuilder()
+            operatorhub.catalogSources().inNamespace(operatorNamespace).resource(new CatalogSourceBuilder()
                     .editOrNewMetadata()
                         .withName("hawtio-catalog")
                         .withNamespace(operatorNamespace)
@@ -315,7 +315,7 @@ public class HawtioOnlineUtils {
                         .withImage(TestConfiguration.getIndexImage())
                         .withSourceType("grpc")
                     .endSpec()
-                .build());
+                .build()).createOr(op -> op.update());
 
             WaitUtils.waitFor(() -> operatorhub.catalogSources().inNamespace(operatorNamespace).withName("hawtio-catalog")
                 .get()
@@ -441,7 +441,7 @@ public class HawtioOnlineUtils {
         final String hawtioCrName = hawtio.getMetadata().getName();
         hawtio.getMetadata().getFinalizers().clear();
 
-        OpenshiftClient.get().resources(Hawtio.class).inNamespace(namespace).createOrReplace(hawtio);
+        OpenshiftClient.get().resources(Hawtio.class).inNamespace(namespace).resource(hawtio).createOr(op -> op.update());
 
         WaitUtils.waitFor(() -> {
             final Resource<Hawtio> resource = OpenshiftClient.get().resources(Hawtio.class)

--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/OpenshiftClient.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/openshift/OpenshiftClient.java
@@ -122,7 +122,7 @@ public class OpenshiftClient extends OpenShift {
             .endMetadata().build();
         // @formatter:on
         if (this.namespaces().withName(name).get() == null) {
-            this.namespaces().create(ns);
+            this.namespaces().resource(ns).create();
             Awaitility.await().until(() -> this.namespaces().withName(name).get() != null);
             WaitUtils.waitFor(() -> this.namespaces().withName(name).get() != null, "Waiting until the namespace " + name + " is created");
         } else {

--- a/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/OperatorNamespaceWatchingTest.java
+++ b/tests/hawtio-test-suite/src/test/java/io/hawt/tests/openshift/OperatorNamespaceWatchingTest.java
@@ -132,7 +132,7 @@ public class OperatorNamespaceWatchingTest extends BaseHawtioOnlineTest {
             Hawtio hawtioIgnored = HawtioOnlineUtils.withBaseHawtio(crNameIgnored, ignoredNamespace, h -> {
                 h.getSpec().setType(HawtioSpec.Type.NAMESPACE);
             });
-            OpenshiftClient.get().resources(Hawtio.class).inNamespace(ignoredNamespace).create(hawtioIgnored);
+            OpenshiftClient.get().resources(Hawtio.class).inNamespace(ignoredNamespace).resource(hawtioIgnored).create();
 
             // Wait for the CR to be created (verify it exists in etcd)
             WaitUtils.waitFor(() -> {
@@ -215,7 +215,7 @@ public class OperatorNamespaceWatchingTest extends BaseHawtioOnlineTest {
             Hawtio crInOperatorNs = HawtioOnlineUtils.withBaseHawtio(crNameInOperatorNs, OPERATOR_NAMESPACE, h -> {
                 h.getSpec().setType(HawtioSpec.Type.NAMESPACE);
             });
-            OpenshiftClient.get().resources(Hawtio.class).inNamespace(OPERATOR_NAMESPACE).create(crInOperatorNs);
+            OpenshiftClient.get().resources(Hawtio.class).inNamespace(OPERATOR_NAMESPACE).resource(crInOperatorNs).create();
 
             // Wait for CR in operator namespace to be created
             WaitUtils.waitFor(() -> {
@@ -234,7 +234,7 @@ public class OperatorNamespaceWatchingTest extends BaseHawtioOnlineTest {
             Hawtio crInIgnoredNs = HawtioOnlineUtils.withBaseHawtio(crNameInIgnoredNs, ignoredNamespace, h -> {
                 h.getSpec().setType(HawtioSpec.Type.NAMESPACE);
             });
-            OpenshiftClient.get().resources(Hawtio.class).inNamespace(ignoredNamespace).create(crInIgnoredNs);
+            OpenshiftClient.get().resources(Hawtio.class).inNamespace(ignoredNamespace).resource(crInIgnoredNs).create();
 
             // Wait for CR in ignored namespace to be created
             WaitUtils.waitFor(() -> {

--- a/tests/springboot/src/main/java/io/hawt/tests/spring/boot/PropertyFileLoginModule.java
+++ b/tests/springboot/src/main/java/io/hawt/tests/spring/boot/PropertyFileLoginModule.java
@@ -46,7 +46,7 @@ public class PropertyFileLoginModule extends AbstractLoginModule {
             Resource config = resourceFactory.newResource(filename);
 
             propertyUserStore.setConfig(config);
-            propertyUserStore.setHotReload(hotReload);
+            propertyUserStore.setReloadInterval(hotReload ? 1 : 0);
 
             final PropertyUserStore prev = PROPERTY_USERSTORES.putIfAbsent(filename, propertyUserStore);
             if (prev == null) {


### PR DESCRIPTION
This PR addresses deprecation warnings in the test modules by updating APIs that have been deprecated in the current Fabric8 Kubernetes Client and Jetty versions.

Changes included:

1. https://redhat.atlassian.net/browse/HAWNG-2172- Replaced deprecated Fabric8 Kubernetes client createOrReplace() and create() usages with the supported resource creation/update APIs, while preserving the existing behavior.
2. https://redhat.atlassian.net/browse/HAWNG-2173- Updated the deprecated Jetty PropertyUserStore.setHotReload(boolean) usage to the recommended Jetty 12 API.