### PR TITLE
chore(deps): Update selenium, selenide, slf4j, junit platform commons.

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -17,13 +17,13 @@
   <properties>
     <http5-version>5.4.3</http5-version>
     <slf4j-version>2.0.11</slf4j-version>
-    <selenium-version>4.40.0</selenium-version>
-    <selenide-version>7.13.0</selenide-version>
+    <selenium-version>4.47.0</selenium-version>
+    <selenide-version>7.17.0</selenide-version>
     <cucumber-version>7.34.6</cucumber-version>
     <testcontainers-version>2.0.5</testcontainers-version>
     <awaitility-version>4.3.0</awaitility-version>
     <logback-classic-version>1.6.1</logback-classic-version>
-    <junit-platform-commons-version>1.14.2</junit-platform-commons-version>
+    <junit-platform-commons-version>1.14.4</junit-platform-commons-version>
     <!-- Used for testing different versions of the Hawtio project then the current one - i.e. testing 4.0.0 with a SNAPSHOT version -->
     <hawtio.bom.version>${project.version}</hawtio.bom.version>
   </properties>


### PR DESCRIPTION
Update Selenium, Selenide and related dependenies to resolve the following issues happening in our CI/CD
```
org.openqa.selenium.devtools.DevToolsException: You are using a no-op implementation of the CDP. 
The most likely reason for this is that Selenium was unable to find an implementation of the CDP protocol that matches your browser. 
Please be sure to include an implementation on the classpath, possibly by adding a new (maven) dependency of `org.seleniumhq.selenium:selenium-devtools-vNN:4.40.0` where `NN` matches the major version of the browser you're using.
```