### PR TITLE
chore(springboot): upgrade to Camel Spring Boot 4.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <spring7-version>7.0.8</spring7-version>
     <spring-boot4-version>4.1.0</spring-boot4-version>
     <!-- Camel -->
-    <camel-spring-boot-version>4.21.0</camel-spring-boot-version>
+    <camel-spring-boot-version>4.22.0</camel-spring-boot-version>
     <!-- Jetty -->
     <jetty12-version>12.1.11</jetty12-version>
 


### PR DESCRIPTION
Camel 4.21.0's camel-observability-services-starter packages its defaults in `classpath:/config/application.properties`, which takes higher precedence than the application's own `application.properties` in Spring Boot's property resolution. 

This silently overrides management settings (port, base path, endpoint exposure), breaking hawtio endpoint discovery. 

Camel 4.22.0 fixes this by contributing defaults via an EnvironmentPostProcessor with lowest precedence, so user configuration wins as expected.

According to https://camel.apache.org/components/next/others/observability-services.html#_configuration

> The customization of the configuration is available for the Spring Boot runtime since version 4.22.0: the starter contributes its defaults as the lowest precedence property source, so any user-provided configuration overrides them following the standard Spring Boot precedence rules. In earlier versions the starter packaged its defaults in classpath:/config/application.properties, which took precedence over the application’s own application.properties due to a [known limitation](https://github.com/spring-projects/spring-boot/issues/24688), so the defaults could only be overridden via higher precedence sources such as environment variables or system properties.