### PR TITLE
fix(e2e): supress the insecure submission form

### DIFF
--- a/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/WebDriver.java
+++ b/tests/hawtio-test-suite/src/main/java/io/hawt/tests/features/setup/WebDriver.java
@@ -54,6 +54,10 @@ public class WebDriver {
             options.addPreference("network.proxy.allow_hijacking_localhost", false);
             // Trust the docker internal network
             options.addPreference("dom.securecontext.allowlist", "172.17.0.1");
+            // Disable Firefox insecure form submission warning dialogs
+            options.addPreference("security.warn_submit_secure_to_insecure", false);
+            options.addPreference("security.warn_submit_insecure", false);
+            options.addPreference("security.warn_submit_insecure.show_once", false);
             // Disable BiDi to prevent OutOfMemoryError from massive console log capture
             options.setCapability("webSocketUrl", false);
             Configuration.browserCapabilities = options;


### PR DESCRIPTION
 Supress the insecure form submission form in Firefox to avoid the following errors:
 ```
UnhandledAlertException: Unexpected confirmEx dialog detected. Performed handler "ignore": The information you have entered on this page will be sent over an insecure connection and could be read by a third party.
Screenshot: file:/workspace/tests/hawtio-test-suite/build/reports/tests/1788412055810.4.png
Page source: file:/workspace/tests/hawtio-test-suite/build/reports/tests/1788412055810.4.html
Timeout: 30s
Caused by: UnhandledAlertException: Unexpected confirmEx dialog detected. Performed handler "ignore": The information you have entered on this page will be sent over an insecure connection and could be read by a third party.
	at com.codeborne.selenide.ex.UIAssertionError.wrapToUIAssertionError(UIAssertionError.java:132)
	at com.codeborne.selenide.ex.UIAssertionError.wrapThrowable(UIAssertionError.java:113)
	at com.codeborne.selenide.ex.UIAssertionError.wrap(UIAssertionError.java:99)
	at com.codeborne.selenide.impl.SelenideElementProxy.invoke(SelenideElementProxy.java:100)
	at jdk.proxy2/jdk.proxy2.$Proxy40.should(Unknown Source)
	at io.hawt.tests.features.setup.LoginLogout.hawtioIsLoaded(LoginLogout.java:101)
	at io.hawt.tests.features.hooks.LoginLogoutHooks.before(LoginLogoutHooks.java:29)
Caused by: org.openqa.selenium.UnhandledAlertException: Unexpected confirmEx dialog detected. Performed handler "ignore": The information you have entered on this page will be sent over an insecure connection and could be read by a third party.

```